### PR TITLE
Fix example script being auto-collected by pytest #57

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_functions = test_*
 python_classes = Test*
-norecursedirs = examples
+norecursedirs = examples .* *.egg _darcs build CVS dist node_modules venv {arch}
 addopts = 
     -v
     --tb=short


### PR DESCRIPTION
pytest was collecting example scripts in examples/ 
my solution : tell pytest to ignore testing examples/ by adding ```  norecursedirs = examples .* *.egg _darcs build CVS dist node_modules venv {arch}``` in ``` pytest.ini ``` 
after this tests ran successfully , closes #57
<img width="633" height="83" alt="image" src="https://github.com/user-attachments/assets/83177810-524f-452d-b2ef-aa9f74a0639f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to exclude recursion into common auxiliary directories (examples, build/dist artifacts, versioning and packaging folders, node_modules, venv, etc.), so test discovery skips those paths. This reduces noise during test runs and speeds up discovery. No other test settings were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->