### PR TITLE
feat: add standardized JSON output formatter

### DIFF
--- a/examples/03_advanced_configuration.py
+++ b/examples/03_advanced_configuration.py
@@ -140,25 +140,15 @@ def main():
             print(f"    Expected: {r.ayah.text[:50]}...")
             print(f"    Got: {r.transcribed_text[:50]}...")
 
-    # Step 8: Export to JSON
+    # Step 8: Export to JSON using canonical formatter
     print("\nStep 8: Exporting results...")
-    import json
+    from munajjam.formatter import format_to_json
 
-    output = []
-    for r in results:
-        output.append({
-            "ayah_number": r.ayah.ayah_number,
-            "start_time": round(r.start_time, 3),
-            "end_time": round(r.end_time, 3),
-            "duration": round(r.duration, 3),
-            "similarity_score": round(r.similarity_score, 3),
-            "overlap_detected": r.overlap_detected,
-            "transcribed_text": r.transcribed_text,
-        })
+    json_output = format_to_json(results, audio_file=audio_path)
 
     output_path = f"surah_{surah_number:03d}_alignment.json"
     with open(output_path, 'w', encoding='utf-8') as f:
-        json.dump(output, f, ensure_ascii=False, indent=2)
+        f.write(json_output)
 
     print(f"  Results saved to: {output_path}")
 

--- a/examples/04_batch_processing.py
+++ b/examples/04_batch_processing.py
@@ -11,6 +11,7 @@ This example demonstrates how to process multiple surahs efficiently:
 from munajjam.transcription import WhisperTranscriber
 from munajjam.core import Aligner
 from munajjam.data import load_surah_ayahs, get_all_surahs
+from munajjam.formatter import format_to_json
 from pathlib import Path
 import json
 import time
@@ -109,23 +110,12 @@ def main():
             # Save results
             output_file = output_directory / f"surah_{surah_number:03d}_alignment.json"
 
-            output_data = {
-                "surah_number": surah_number,
-                "stats": stats,
-                "results": [
-                    {
-                        "ayah_number": r.ayah.ayah_number,
-                        "start_time": round(r.start_time, 3),
-                        "end_time": round(r.end_time, 3),
-                        "similarity_score": round(r.similarity_score, 3),
-                        "overlap_detected": r.overlap_detected,
-                    }
-                    for r in results
-                ]
-            }
+            json_output = format_to_json(
+                results, audio_file=str(audio_file),
+            )
 
             with open(output_file, 'w', encoding='utf-8') as f:
-                json.dump(output_data, f, ensure_ascii=False, indent=2)
+                f.write(json_output)
 
             all_stats.append(stats)
 

--- a/munajjam/examples/basic_usage.py
+++ b/munajjam/examples/basic_usage.py
@@ -7,13 +7,13 @@ This example demonstrates the core workflow:
 3. Output results as JSON
 """
 
-import json
 from pathlib import Path
 
 # Import core components
 from munajjam.transcription import WhisperTranscriber
 from munajjam.core import align
 from munajjam.data import load_surah_ayahs
+from munajjam.formatter import format_to_json
 
 
 def process_surah(audio_path: str, surah_id: int, reciter: str = "Unknown"):
@@ -66,32 +66,21 @@ def process_surah(audio_path: str, surah_id: int, reciter: str = "Unknown"):
     if len(results) > 5:
         print(f"   ... and {len(results) - 5} more")
     
-    # Step 4: Create output
+    # Step 4: Create output using canonical formatter
     print("\n📄 Step 4: Creating JSON output...")
-    
-    output = []
-    for result in results:
-        output.append({
-            "id": result.ayah.ayah_number,
-            "sura_id": result.ayah.surah_id,
-            "ayah_index": result.ayah.ayah_number - 1,
-            "start": round(result.start_time, 2),
-            "end": round(result.end_time, 2),
-            "transcribed_text": result.transcribed_text,
-            "corrected_text": result.ayah.text,
-            "similarity_score": round(result.similarity_score, 3),
-        })
-    
-    return output
+
+    json_output = format_to_json(results, audio_file=audio_path, reciter=reciter)
+
+    return json_output
 
 
-def save_to_json(output: list, output_path: str):
-    """Save output to JSON file."""
+def save_to_json(json_output: str, output_path: str):
+    """Save JSON output string to file."""
     print(f"\n💾 Saving to: {output_path}")
-    
+
     with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(output, f, ensure_ascii=False, indent=2)
-    
+        f.write(json_output)
+
     print("   ✅ Saved successfully!")
 
 

--- a/munajjam/examples/test_alignment.py
+++ b/munajjam/examples/test_alignment.py
@@ -22,6 +22,7 @@ from munajjam.transcription import WhisperTranscriber
 from munajjam.transcription.silence import detect_silences
 from munajjam.core import Aligner, normalize_arabic, similarity
 from munajjam.data import load_surah_ayahs, get_ayah_count
+from munajjam.formatter import format_to_json
 from munajjam.models import Segment, SegmentType
 
 
@@ -92,23 +93,12 @@ def test_with_transcription(audio_path: str, surah_id: int):
         print(f"   Transcribed: {trans_preview}")
         print()
     
-    # Generate JSON output
+    # Generate JSON output using canonical formatter
     output_file = f"output_surah_{surah_id:03d}.json"
-    output = []
-    for result in results:
-        output.append({
-            "id": result.ayah.ayah_number,
-            "sura_id": result.ayah.surah_id,
-            "ayah_index": result.ayah.ayah_number - 1,
-            "start": round(result.start_time, 2),
-            "end": round(result.end_time, 2),
-            "transcribed_text": result.transcribed_text,
-            "corrected_text": result.ayah.text,
-            "similarity_score": round(result.similarity_score, 3),
-        })
-    
+    json_output = format_to_json(results, audio_file=audio_path)
+
     with open(output_file, "w", encoding="utf-8") as f:
-        json.dump(output, f, ensure_ascii=False, indent=2)
+        f.write(json_output)
     print(f"💾 Saved to: {output_file}")
     
     # Summary

--- a/munajjam/munajjam/__init__.py
+++ b/munajjam/munajjam/__init__.py
@@ -19,22 +19,31 @@ Usage:
         print(f"Ayah {result.ayah.ayah_number}: {result.start_time:.2f}s - {result.end_time:.2f}s")
 """
 
+from munajjam.config import MunajjamSettings, configure, get_settings
+from munajjam.exceptions import (
+    AlignmentError,
+    AudioFileError,
+    ConfigurationError,
+    ModelNotLoadedError,
+    MunajjamError,
+    QuranDataError,
+    TranscriptionError,
+)
+from munajjam.formatter import (
+    FormattedAyahResult,
+    FormattedOutput,
+    FormattedSummary,
+    format_result,
+    format_results,
+    format_results_list,
+    format_to_json,
+)
 from munajjam.models import (
     AlignmentResult,
     Ayah,
     Segment,
     SegmentType,
     Surah,
-)
-from munajjam.config import MunajjamSettings, get_settings, configure
-from munajjam.exceptions import (
-    MunajjamError,
-    TranscriptionError,
-    AlignmentError,
-    ConfigurationError,
-    AudioFileError,
-    ModelNotLoadedError,
-    QuranDataError,
 )
 
 __version__ = "2.0.0a1"
@@ -51,6 +60,14 @@ __all__ = [
     "MunajjamSettings",
     "get_settings",
     "configure",
+    # Formatter
+    "FormattedOutput",
+    "FormattedAyahResult",
+    "FormattedSummary",
+    "format_result",
+    "format_results",
+    "format_results_list",
+    "format_to_json",
     # Exceptions
     "MunajjamError",
     "TranscriptionError",

--- a/munajjam/munajjam/formatter.py
+++ b/munajjam/munajjam/formatter.py
@@ -1,0 +1,209 @@
+"""
+Standardized JSON output formatter for Munajjam alignment results.
+
+Provides a canonical schema for JSON output that all consumers should use
+instead of hand-rolling their own dict structures.
+
+Usage::
+
+    from munajjam.formatter import format_results, format_to_json
+
+    output = format_results(results, audio_file="001.wav", reciter="Badr Al-Turki")
+    json_str = format_to_json(results)
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from munajjam.models.result import AlignmentResult
+from munajjam.models.surah import SURAH_NAMES
+
+OUTPUT_SCHEMA_VERSION = "1.0"
+
+
+class FormattedSummary(BaseModel):
+    """Aggregate statistics for a set of alignment results."""
+
+    model_config = ConfigDict(frozen=True)
+
+    average_similarity: float = Field(
+        ..., description="Mean similarity score across all results",
+    )
+    high_confidence_count: int = Field(
+        ..., description="Number of results with similarity >= 0.8",
+    )
+    high_confidence_percentage: float = Field(
+        ..., description="Percentage of high-confidence results (0.0-100.0)",
+    )
+    overlap_count: int = Field(
+        ..., description="Number of results with overlap detected",
+    )
+    total_duration: float = Field(
+        ..., description="Total duration of all aligned segments in seconds",
+    )
+
+
+class FormattedAyahResult(BaseModel):
+    """Canonical per-ayah alignment result."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ayah_id: int = Field(
+        ..., description="Global unique ayah ID (1-6236)", ge=1, le=6236,
+    )
+    surah_number: int = Field(
+        ..., description="Surah number (1-114)", ge=1, le=114,
+    )
+    ayah_number: int = Field(
+        ..., description="Ayah number within surah (1-based)", ge=1,
+    )
+    start_time: float = Field(
+        ..., description="Start time in seconds", ge=0.0,
+    )
+    end_time: float = Field(
+        ..., description="End time in seconds", ge=0.0,
+    )
+    duration: float = Field(
+        ..., description="Duration in seconds", ge=0.0,
+    )
+    transcribed_text: str = Field(..., description="Text transcribed from audio")
+    reference_text: str = Field(..., description="Canonical Quran text for this ayah")
+    similarity_score: float = Field(
+        ..., description="Similarity score (0.0-1.0)", ge=0.0, le=1.0,
+    )
+    is_high_confidence: bool = Field(
+        ..., description="Whether similarity >= 0.8",
+    )
+    overlap_detected: bool = Field(
+        ..., description="Whether overlap was detected",
+    )
+
+
+class FormattedOutput(BaseModel):
+    """Top-level canonical output envelope."""
+
+    model_config = ConfigDict(frozen=True)
+
+    version: str = Field(..., description="Schema version")
+    surah_number: int | None = Field(
+        None, description="Surah number if single-surah output",
+    )
+    surah_name: str | None = Field(
+        None, description="Arabic surah name if single-surah output",
+    )
+    total_ayahs: int = Field(..., description="Number of ayahs in results")
+    audio_file: str | None = Field(None, description="Path to audio file")
+    reciter: str | None = Field(None, description="Reciter name")
+    created_at: str = Field(..., description="ISO 8601 creation timestamp")
+    results: list[FormattedAyahResult] = Field(
+        ..., description="Per-ayah alignment results",
+    )
+    summary: FormattedSummary = Field(..., description="Aggregate statistics")
+
+
+def format_result(result: AlignmentResult) -> FormattedAyahResult:
+    """Format a single AlignmentResult into the canonical schema."""
+    rounded_start = round(result.start_time, 3)
+    rounded_end = round(result.end_time, 3)
+
+    return FormattedAyahResult(
+        ayah_id=result.ayah.id,
+        surah_number=result.ayah.surah_id,
+        ayah_number=result.ayah.ayah_number,
+        start_time=rounded_start,
+        end_time=rounded_end,
+        duration=max(0.0, round(rounded_end - rounded_start, 3)),
+        transcribed_text=result.transcribed_text,
+        reference_text=result.ayah.text,
+        similarity_score=round(result.similarity_score, 4),
+        is_high_confidence=result.is_high_confidence,
+        overlap_detected=result.overlap_detected,
+    )
+
+
+def _compute_summary(
+    formatted: list[FormattedAyahResult],
+) -> FormattedSummary:
+    """Compute aggregate summary statistics from formatted results."""
+    if not formatted:
+        return FormattedSummary(
+            average_similarity=0.0,
+            high_confidence_count=0,
+            high_confidence_percentage=0.0,
+            overlap_count=0,
+            total_duration=0.0,
+        )
+
+    total = len(formatted)
+    high_count = sum(1 for r in formatted if r.is_high_confidence)
+
+    return FormattedSummary(
+        average_similarity=round(
+            sum(r.similarity_score for r in formatted) / total, 4,
+        ),
+        high_confidence_count=high_count,
+        high_confidence_percentage=round(high_count / total * 100, 1),
+        overlap_count=sum(1 for r in formatted if r.overlap_detected),
+        total_duration=round(sum(r.duration for r in formatted), 3),
+    )
+
+
+def _detect_surah(
+    formatted: list[FormattedAyahResult],
+) -> tuple[int | None, str | None]:
+    """Detect surah number and name if all results share the same surah."""
+    if not formatted:
+        return None, None
+
+    surah_ids = {r.surah_number for r in formatted}
+    if len(surah_ids) == 1:
+        (surah_id,) = surah_ids
+        return surah_id, SURAH_NAMES.get(surah_id)
+
+    return None, None
+
+
+def format_results(
+    results: list[AlignmentResult],
+    *,
+    audio_file: str | None = None,
+    reciter: str | None = None,
+) -> FormattedOutput:
+    """Format alignment results into the canonical output envelope."""
+    formatted = [format_result(r) for r in results]
+    surah_number, surah_name = _detect_surah(formatted)
+    summary = _compute_summary(formatted)
+
+    return FormattedOutput(
+        version=OUTPUT_SCHEMA_VERSION,
+        surah_number=surah_number,
+        surah_name=surah_name,
+        total_ayahs=len(formatted),
+        audio_file=audio_file,
+        reciter=reciter,
+        created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        results=formatted,
+        summary=summary,
+    )
+
+
+def format_results_list(
+    results: list[AlignmentResult],
+) -> list[FormattedAyahResult]:
+    """Format results as a flat list without the envelope."""
+    return [format_result(r) for r in results]
+
+
+def format_to_json(
+    results: list[AlignmentResult],
+    *,
+    audio_file: str | None = None,
+    reciter: str | None = None,
+    indent: int = 2,
+) -> str:
+    """Format results directly to a JSON string."""
+    output = format_results(results, audio_file=audio_file, reciter=reciter)
+    return output.model_dump_json(indent=indent)

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,0 +1,389 @@
+"""
+Tests for the standardized JSON output formatter.
+
+Verifies the canonical schema, formatting functions, rounding precision,
+metadata handling, serialization round-trips, and edge cases.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from munajjam.formatter import (
+    FormattedAyahResult,
+    FormattedOutput,
+    format_result,
+    format_results,
+    format_results_list,
+    format_to_json,
+)
+from munajjam.models import AlignmentResult, Ayah
+
+# --------------- Fixtures ---------------
+
+
+@pytest.fixture()
+def ayah_1() -> Ayah:
+    return Ayah(
+        id=1,
+        surah_id=1,
+        ayah_number=1,
+        text="بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+    )
+
+
+@pytest.fixture()
+def ayah_2() -> Ayah:
+    return Ayah(
+        id=2,
+        surah_id=1,
+        ayah_number=2,
+        text="الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ",
+    )
+
+
+@pytest.fixture()
+def ayah_other_surah() -> Ayah:
+    return Ayah(
+        id=6231,
+        surah_id=114,
+        ayah_number=1,
+        text="قُلْ أَعُوذُ بِرَبِّ النَّاسِ",
+    )
+
+
+@pytest.fixture()
+def result_1(ayah_1: Ayah) -> AlignmentResult:
+    return AlignmentResult(
+        ayah=ayah_1,
+        start_time=5.1234567,
+        end_time=8.9876543,
+        transcribed_text="بسم الله الرحمن الرحيم",
+        similarity_score=0.95123,
+    )
+
+
+@pytest.fixture()
+def result_2(ayah_2: Ayah) -> AlignmentResult:
+    return AlignmentResult(
+        ayah=ayah_2,
+        start_time=9.0,
+        end_time=13.5,
+        transcribed_text="الحمد لله رب العالمين",
+        similarity_score=0.72,
+        overlap_detected=True,
+    )
+
+
+@pytest.fixture()
+def result_other_surah(ayah_other_surah: Ayah) -> AlignmentResult:
+    return AlignmentResult(
+        ayah=ayah_other_surah,
+        start_time=0.0,
+        end_time=3.0,
+        transcribed_text="قل اعوذ برب الناس",
+        similarity_score=0.88,
+    )
+
+
+# --------------- format_result() ---------------
+
+
+class TestFormatResult:
+    """Tests for formatting a single AlignmentResult."""
+
+    def test_returns_formatted_ayah_result(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        formatted = format_result(result_1)
+        assert isinstance(formatted, FormattedAyahResult)
+
+    def test_ayah_fields_mapped(
+        self, result_1: AlignmentResult, ayah_1: Ayah,
+    ) -> None:
+        formatted = format_result(result_1)
+        assert formatted.ayah_id == ayah_1.id
+        assert formatted.surah_number == ayah_1.surah_id
+        assert formatted.ayah_number == ayah_1.ayah_number
+
+    def test_reference_text_is_ayah_text(
+        self, result_1: AlignmentResult, ayah_1: Ayah,
+    ) -> None:
+        formatted = format_result(result_1)
+        assert formatted.reference_text == ayah_1.text
+
+    def test_transcribed_text_preserved(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        formatted = format_result(result_1)
+        assert formatted.transcribed_text == result_1.transcribed_text
+
+    def test_rounding_precision_times(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        """start_time, end_time, duration rounded to 3 decimal places."""
+        formatted = format_result(result_1)
+        assert formatted.start_time == 5.123
+        assert formatted.end_time == 8.988
+        # Duration computed from already-rounded values for consistency
+        assert formatted.duration == round(8.988 - 5.123, 3)
+
+    def test_duration_consistent_with_times(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        """duration must equal end_time - start_time in the output."""
+        formatted = format_result(result_1)
+        assert formatted.duration == round(
+            formatted.end_time - formatted.start_time, 3,
+        )
+
+    def test_rounding_precision_similarity(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        """similarity_score rounded to 4 decimal places."""
+        formatted = format_result(result_1)
+        assert formatted.similarity_score == 0.9512
+
+    def test_computed_fields_match_source(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        formatted = format_result(result_1)
+        assert formatted.is_high_confidence == result_1.is_high_confidence
+        assert formatted.overlap_detected == result_1.overlap_detected
+
+    def test_overlap_detected_true(
+        self, result_2: AlignmentResult,
+    ) -> None:
+        formatted = format_result(result_2)
+        assert formatted.overlap_detected is True
+
+    def test_low_confidence_result(
+        self, result_2: AlignmentResult,
+    ) -> None:
+        """Result with score 0.72 should NOT be high confidence."""
+        formatted = format_result(result_2)
+        assert formatted.is_high_confidence is False
+
+
+# --------------- format_results() ---------------
+
+
+class TestFormatResults:
+    """Tests for formatting a list of results into the full envelope."""
+
+    def test_returns_formatted_output(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        assert isinstance(output, FormattedOutput)
+
+    def test_version_field(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1])
+        assert output.version == "1.0"
+
+    def test_total_ayahs(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        assert output.total_ayahs == 2
+
+    def test_results_list(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        assert len(output.results) == 2
+        assert all(isinstance(r, FormattedAyahResult) for r in output.results)
+
+    def test_created_at_is_iso(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1])
+        # Should parse without error
+        parsed = datetime.fromisoformat(output.created_at)
+        assert parsed.tzinfo is not None  # Must be timezone-aware
+
+    def test_surah_metadata_single_surah(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        """When all results share the same surah, metadata is populated."""
+        output = format_results([result_1, result_2])
+        assert output.surah_number == 1
+        assert output.surah_name == "الفاتحة"
+
+    def test_surah_metadata_mixed_surahs(
+        self,
+        result_1: AlignmentResult,
+        result_other_surah: AlignmentResult,
+    ) -> None:
+        """When results span multiple surahs, metadata is None."""
+        output = format_results([result_1, result_other_surah])
+        assert output.surah_number is None
+        assert output.surah_name is None
+
+    def test_optional_metadata_provided(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        output = format_results(
+            [result_1], audio_file="surah_001.wav", reciter="Badr Al-Turki",
+        )
+        assert output.audio_file == "surah_001.wav"
+        assert output.reciter == "Badr Al-Turki"
+
+    def test_optional_metadata_default_none(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1])
+        assert output.audio_file is None
+        assert output.reciter is None
+
+
+# --------------- FormattedSummary ---------------
+
+
+class TestFormattedSummary:
+    """Tests for summary statistics computation."""
+
+    def test_average_similarity(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        expected_avg = round((0.9512 + 0.72) / 2, 4)
+        assert output.summary.average_similarity == expected_avg
+
+    def test_high_confidence_count(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        # result_1: 0.95 (high), result_2: 0.72 (not high)
+        assert output.summary.high_confidence_count == 1
+
+    def test_high_confidence_percentage(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        assert output.summary.high_confidence_percentage == 50.0
+
+    def test_overlap_count(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        # Only result_2 has overlap_detected=True
+        assert output.summary.overlap_count == 1
+
+    def test_total_duration(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        output = format_results([result_1, result_2])
+        # Duration computed from rounded times for consistency
+        r1_dur = round(round(8.9876543, 3) - round(5.1234567, 3), 3)
+        r2_dur = round(round(13.5, 3) - round(9.0, 3), 3)
+        assert output.summary.total_duration == round(r1_dur + r2_dur, 3)
+
+
+# --------------- Empty results ---------------
+
+
+class TestEmptyResults:
+    """Tests for handling empty result lists."""
+
+    def test_empty_results_valid_output(self) -> None:
+        output = format_results([])
+        assert isinstance(output, FormattedOutput)
+        assert output.total_ayahs == 0
+        assert output.results == []
+
+    def test_empty_results_summary_zeros(self) -> None:
+        output = format_results([])
+        assert output.summary.average_similarity == 0.0
+        assert output.summary.high_confidence_count == 0
+        assert output.summary.high_confidence_percentage == 0.0
+        assert output.summary.overlap_count == 0
+        assert output.summary.total_duration == 0.0
+
+    def test_empty_results_no_surah_metadata(self) -> None:
+        output = format_results([])
+        assert output.surah_number is None
+        assert output.surah_name is None
+
+
+# --------------- format_results_list() ---------------
+
+
+class TestFormatResultsList:
+    """Tests for the flat list convenience function."""
+
+    def test_returns_list(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        result = format_results_list([result_1, result_2])
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_returns_formatted_ayah_results(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        result = format_results_list([result_1])
+        assert all(isinstance(r, FormattedAyahResult) for r in result)
+
+    def test_empty_list(self) -> None:
+        assert format_results_list([]) == []
+
+
+# --------------- format_to_json() ---------------
+
+
+class TestFormatToJson:
+    """Tests for the JSON string convenience function."""
+
+    def test_returns_string(self, result_1: AlignmentResult) -> None:
+        result = format_to_json([result_1])
+        assert isinstance(result, str)
+
+    def test_valid_json(self, result_1: AlignmentResult) -> None:
+        result = format_to_json([result_1])
+        parsed = json.loads(result)
+        assert isinstance(parsed, dict)
+        assert "version" in parsed
+        assert "results" in parsed
+
+    def test_json_round_trip(
+        self, result_1: AlignmentResult, result_2: AlignmentResult,
+    ) -> None:
+        """Serialize to JSON and parse back yields valid FormattedOutput."""
+        json_str = format_to_json([result_1, result_2])
+        parsed = FormattedOutput.model_validate_json(json_str)
+        assert parsed.total_ayahs == 2
+        assert len(parsed.results) == 2
+
+    def test_json_contains_arabic_text(
+        self, result_1: AlignmentResult,
+    ) -> None:
+        """JSON should use ensure_ascii=False for Arabic text."""
+        result = format_to_json([result_1])
+        assert "بسم" in result  # Arabic should be literal, not escaped
+
+
+# --------------- Public API export ---------------
+
+
+class TestPublicAPI:
+    """Verify formatter is exported from the top-level munajjam package."""
+
+    def test_format_results_importable(self) -> None:
+        from munajjam import format_results as fn
+        assert callable(fn)
+
+    def test_format_to_json_importable(self) -> None:
+        from munajjam import format_to_json as fn
+        assert callable(fn)
+
+    def test_formatted_output_importable(self) -> None:
+        from munajjam import FormattedOutput as cls
+        assert cls is not None
+
+    def test_formatted_ayah_result_importable(self) -> None:
+        from munajjam import FormattedAyahResult as cls
+        assert cls is not None


### PR DESCRIPTION
## Summary

- Add `munajjam/formatter.py` with canonical Pydantic output schema: `FormattedOutput`, `FormattedAyahResult`, `FormattedSummary`
- Export 4 public functions: `format_results()`, `format_to_json()`, `format_results_list()`, `format_result()`
- Update all 4 example files to use the formatter instead of inline dict building
- Add 38 unit tests covering rounding precision, summary stats, surah auto-detection, empty results, JSON round-trips, and public API exports

## Details

### Problem
The codebase had 4 incompatible JSON output shapes across examples, each hand-rolling its own dict structure with inconsistent field names, rounding precision, and missing metadata.

### Solution
A single canonical schema powered by Pydantic v2 frozen models with:
- **Field validators** (`ge`/`le` constraints matching documented ranges)
- **Duration consistency** (computed from already-rounded start/end times)
- **Negative duration guard** (`max(0.0, ...)` for sub-millisecond rounding edge cases)
- **Surah auto-detection** (populates surah metadata when all results share the same surah)
- **Schema versioning** (`OUTPUT_SCHEMA_VERSION = "1.0"`)

### Files changed
| File | Change |
|------|--------|
| `munajjam/munajjam/formatter.py` | **NEW** - Core formatter module (3 models, 4 functions) |
| `tests/unit/test_formatter.py` | **NEW** - 38 unit tests |
| `munajjam/munajjam/__init__.py` | Updated exports |
| `munajjam/examples/basic_usage.py` | Replaced inline dicts with `format_to_json()` |
| `munajjam/examples/test_alignment.py` | Replaced inline dicts with `format_to_json()` |
| `examples/03_advanced_configuration.py` | Replaced inline dicts with `format_to_json()` |
| `examples/04_batch_processing.py` | Replaced inline dicts with `format_to_json()` |

## Test plan

- [x] 38 new formatter unit tests pass
- [x] All 127 tests pass (38 new + 89 existing)
- [x] ruff check: all passed
- [x] mypy: 0 errors
- [x] No inline dict building remains in examples

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized JSON output formatter with structured metadata (version, audio file, reciter, timestamp) and comprehensive result summaries including statistics.
  * Added flexible formatting utilities for individual results, result lists, and complete output envelopes.

* **Refactor**
  * Updated examples to use the canonical formatter for consistent JSON output generation.

* **Tests**
  * Added comprehensive test coverage for formatter functionality across all output formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->