### PR TITLE
feat: benchmark harness + leaderboard (Issue #45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,9 +115,10 @@ output_*/
 cache/
 
 # Generated JSON files (alignment outputs)
-# Allow example outputs in munajjam/examples
+# Allow example outputs and benchmark ground truth
 *.json
 !munajjam/examples/*.json
+!benchmarks/ground_truth/*.json
 
 # Generated HTML/CSV (analysis outputs)
 *.html

--- a/benchmarks/ground_truth/surah_001.json
+++ b/benchmarks/ground_truth/surah_001.json
@@ -1,0 +1,50 @@
+{
+  "surah_id": 1,
+  "reciter": "sample",
+  "audio_filename": "surah_001_sample.wav",
+  "notes": "Ground truth derived from verified example output (output_surah_001.json). All similarity scores >= 0.963.",
+  "ayahs": [
+    {
+      "ayah_number": 1,
+      "start_time": 5.72,
+      "end_time": 9.74,
+      "text": "بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ"
+    },
+    {
+      "ayah_number": 2,
+      "start_time": 10.28,
+      "end_time": 14.90,
+      "text": "الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ"
+    },
+    {
+      "ayah_number": 3,
+      "start_time": 15.19,
+      "end_time": 18.77,
+      "text": "الرَّحْمَنِ الرَّحِيمِ"
+    },
+    {
+      "ayah_number": 4,
+      "start_time": 18.98,
+      "end_time": 22.76,
+      "text": "مَالِكِ يَوْمِ الدِّينِ"
+    },
+    {
+      "ayah_number": 5,
+      "start_time": 23.02,
+      "end_time": 28.43,
+      "text": "إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ"
+    },
+    {
+      "ayah_number": 6,
+      "start_time": 28.74,
+      "end_time": 33.28,
+      "text": "اهْدِنَا الصِّرَاطَ الْمُسْتَقِيمَ"
+    },
+    {
+      "ayah_number": 7,
+      "start_time": 33.82,
+      "end_time": 46.37,
+      "text": "صِرَاطَ الَّذِينَ أَنْعَمْتَ عَلَيْهِمْ غَيْرِ الْمَغْضُوبِ عَلَيْهِمْ وَلَا الضَّالِّينَ"
+    }
+  ]
+}

--- a/benchmarks/ground_truth/surah_112.json
+++ b/benchmarks/ground_truth/surah_112.json
@@ -1,0 +1,32 @@
+{
+  "surah_id": 112,
+  "reciter": "synthetic",
+  "audio_filename": "surah_112_synthetic.wav",
+  "notes": "Synthetic ground truth for benchmarking. Not derived from real audio.",
+  "ayahs": [
+    {
+      "ayah_number": 1,
+      "start_time": 1.0,
+      "end_time": 4.2,
+      "text": "قُلْ هُوَ اللَّهُ أَحَدٌ"
+    },
+    {
+      "ayah_number": 2,
+      "start_time": 4.5,
+      "end_time": 7.3,
+      "text": "اللَّهُ الصَّمَدُ"
+    },
+    {
+      "ayah_number": 3,
+      "start_time": 7.6,
+      "end_time": 11.0,
+      "text": "لَمْ يَلِدْ وَلَمْ يُولَدْ"
+    },
+    {
+      "ayah_number": 4,
+      "start_time": 11.3,
+      "end_time": 15.5,
+      "text": "وَلَمْ يَكُنْ لَهُ كُفُوًا أَحَدٌ"
+    }
+  ]
+}

--- a/munajjam/munajjam/benchmark/__init__.py
+++ b/munajjam/munajjam/benchmark/__init__.py
@@ -1,0 +1,38 @@
+"""
+Benchmark harness for Munajjam alignment quality evaluation.
+
+Provides ground-truth loading, metric computation, benchmark running,
+and Markdown leaderboard generation.
+"""
+
+from munajjam.benchmark.leaderboard import generate_leaderboard, save_leaderboard
+from munajjam.benchmark.loader import list_ground_truth_files, load_ground_truth
+from munajjam.benchmark.metrics import (
+    compute_avg_similarity,
+    compute_mae,
+    compute_pct_high_confidence,
+    compute_strategy_metrics,
+)
+from munajjam.benchmark.models import (
+    BenchmarkReport,
+    GroundTruthAyah,
+    GroundTruthSurah,
+    StrategyMetrics,
+)
+from munajjam.benchmark.runner import BenchmarkRunner
+
+__all__ = [
+    "BenchmarkReport",
+    "BenchmarkRunner",
+    "GroundTruthAyah",
+    "GroundTruthSurah",
+    "StrategyMetrics",
+    "compute_avg_similarity",
+    "compute_mae",
+    "compute_pct_high_confidence",
+    "compute_strategy_metrics",
+    "generate_leaderboard",
+    "list_ground_truth_files",
+    "load_ground_truth",
+    "save_leaderboard",
+]

--- a/munajjam/munajjam/benchmark/leaderboard.py
+++ b/munajjam/munajjam/benchmark/leaderboard.py
@@ -1,0 +1,143 @@
+"""
+Markdown leaderboard generator for benchmark results.
+
+Produces a formatted Markdown string with per-surah tables
+and an overall summary table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import groupby
+from pathlib import Path
+
+from munajjam.benchmark.models import BenchmarkReport, StrategyMetrics
+
+_TABLE_HEADER = (
+    "| Strategy | MAE Start (s) | MAE End (s) | Avg Similarity "
+    "| % High Confidence | Runtime (s) | Ayahs |\n"
+    "|----------|---------------|-------------|----------------"
+    "|-------------------|-------------|-------|"
+)
+
+
+@dataclass
+class _SummaryRow:
+    """Internal row for the overall summary table (not a Pydantic model)."""
+
+    strategy: str
+    mae_start: float
+    mae_end: float
+    avg_similarity: float
+    pct_high_confidence: float
+    runtime_seconds: float
+    ayah_count: int
+
+
+def _format_row(
+    strategy: str,
+    mae_start: float,
+    mae_end: float,
+    avg_similarity: float,
+    pct_high_confidence: float,
+    runtime_seconds: float,
+    ayah_count: int,
+) -> str:
+    return (
+        f"| {strategy:<8} "
+        f"| {mae_start:>13.3f} "
+        f"| {mae_end:>11.3f} "
+        f"| {avg_similarity:>14.3f} "
+        f"| {pct_high_confidence:>17.1f} "
+        f"| {runtime_seconds:>11.3f} "
+        f"| {ayah_count:>5} |"
+    )
+
+
+def _format_metrics_row(m: StrategyMetrics) -> str:
+    return _format_row(
+        m.strategy,
+        m.mae_start,
+        m.mae_end,
+        m.avg_similarity,
+        m.pct_high_confidence,
+        m.runtime_seconds,
+        m.ayah_count,
+    )
+
+
+def generate_leaderboard(report: BenchmarkReport) -> str:
+    """Generate a Markdown leaderboard from benchmark results.
+
+    Produces:
+    - A header with generation timestamp and library version
+    - One section per surah, rows sorted by MAE start ascending
+    - An overall summary with per-strategy means across all surahs
+
+    Args:
+        report: BenchmarkReport to render.
+
+    Returns:
+        Formatted Markdown string.
+    """
+    lines: list[str] = [
+        "# Munajjam Alignment Benchmark Leaderboard\n",
+        f"\n> Generated: {report.generated_at}  \n",
+        f"> Library version: `{report.munajjam_version}`\n",
+        "\n---\n",
+    ]
+
+    # Per-surah sections
+    sorted_results = sorted(
+        report.results,
+        key=lambda r: (r.surah_id, r.mae_start),
+    )
+    for surah_id, group in groupby(sorted_results, key=lambda r: r.surah_id):
+        group_list = list(group)
+        lines.append(f"\n## Surah {surah_id}\n\n")
+        lines.append(_TABLE_HEADER + "\n")
+        for m in group_list:
+            lines.append(_format_metrics_row(m) + "\n")
+
+    # Overall summary
+    lines.append("\n---\n\n## Overall Summary (mean across all surahs)\n\n")
+    lines.append(_TABLE_HEADER + "\n")
+
+    strategies = sorted({m.strategy for m in report.results})
+    for strat in strategies:
+        strat_results = [m for m in report.results if m.strategy == strat]
+        n = len(strat_results)
+        if n == 0:
+            continue
+        summary = _SummaryRow(
+            strategy=strat,
+            mae_start=sum(m.mae_start for m in strat_results) / n,
+            mae_end=sum(m.mae_end for m in strat_results) / n,
+            avg_similarity=sum(m.avg_similarity for m in strat_results) / n,
+            pct_high_confidence=sum(m.pct_high_confidence for m in strat_results) / n,
+            runtime_seconds=sum(m.runtime_seconds for m in strat_results) / n,
+            ayah_count=sum(m.ayah_count for m in strat_results),
+        )
+        lines.append(
+            _format_row(
+                summary.strategy,
+                summary.mae_start,
+                summary.mae_end,
+                summary.avg_similarity,
+                summary.pct_high_confidence,
+                summary.runtime_seconds,
+                summary.ayah_count,
+            )
+            + "\n",
+        )
+
+    return "".join(lines)
+
+
+def save_leaderboard(report: BenchmarkReport, output_path: Path) -> None:
+    """Write the leaderboard to a Markdown file.
+
+    Creates parent directories if they do not exist.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(generate_leaderboard(report), encoding="utf-8")

--- a/munajjam/munajjam/benchmark/loader.py
+++ b/munajjam/munajjam/benchmark/loader.py
@@ -1,0 +1,49 @@
+"""
+Ground-truth file loader for the benchmark harness.
+"""
+
+import json
+from pathlib import Path
+
+from munajjam.benchmark.models import GroundTruthSurah
+
+
+def load_ground_truth(path: Path | str) -> GroundTruthSurah:
+    """Load and validate a single ground-truth JSON file.
+
+    Args:
+        path: Path to the ground-truth JSON file.
+
+    Returns:
+        Validated GroundTruthSurah instance.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        IsADirectoryError: If the path is a directory.
+        json.JSONDecodeError: If the file is not valid JSON.
+        pydantic.ValidationError: If the data fails validation.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Ground truth file not found: {path}")
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    return GroundTruthSurah.model_validate(data)
+
+
+def list_ground_truth_files(ground_truth_dir: Path) -> list[Path]:
+    """Return all .json files in the ground-truth directory, sorted.
+
+    Args:
+        ground_truth_dir: Directory containing ground-truth JSON files.
+
+    Returns:
+        Sorted list of Path objects for each JSON file.
+
+    Raises:
+        FileNotFoundError: If the directory does not exist.
+    """
+    if not ground_truth_dir.is_dir():
+        msg = f"Ground truth directory not found: {ground_truth_dir}"
+        raise FileNotFoundError(msg)
+    return sorted(ground_truth_dir.glob("*.json"))

--- a/munajjam/munajjam/benchmark/metrics.py
+++ b/munajjam/munajjam/benchmark/metrics.py
@@ -1,0 +1,78 @@
+"""
+Pure metric computation functions for the benchmark harness.
+
+All functions are side-effect-free and operate on in-memory data only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from munajjam.benchmark.models import GroundTruthSurah, StrategyMetrics
+from munajjam.models import AlignmentResult
+
+
+def compute_mae(predicted: list[float], actual: list[float]) -> float:
+    """Compute mean absolute error between two lists of values.
+
+    Uses min(len(predicted), len(actual)) pairs for comparison,
+    so mismatched lengths degrade gracefully.
+
+    Returns 0.0 if either list is empty.
+    """
+    if not predicted or not actual:
+        return 0.0
+    n = min(len(predicted), len(actual))
+    return sum(abs(p - a) for p, a in zip(predicted[:n], actual[:n])) / n  # noqa: B905
+
+
+def compute_avg_similarity(results: list[AlignmentResult]) -> float:
+    """Compute average similarity score across alignment results.
+
+    Returns 0.0 if results is empty.
+    """
+    if not results:
+        return 0.0
+    return sum(r.similarity_score for r in results) / len(results)
+
+
+def compute_pct_high_confidence(results: list[AlignmentResult]) -> float:
+    """Compute percentage of results with high confidence (similarity >= 0.8).
+
+    Returns 0.0 if results is empty.
+    """
+    if not results:
+        return 0.0
+    return (sum(1 for r in results if r.is_high_confidence) / len(results)) * 100.0
+
+
+def compute_strategy_metrics(
+    strategy: str,
+    surah_id: int,
+    results: list[AlignmentResult],
+    ground_truth: GroundTruthSurah,
+    runtime_seconds: float,
+) -> StrategyMetrics:
+    """Assemble all metrics for one strategy + surah combination.
+
+    Matches predicted results to ground-truth ayahs by ayah_number order.
+    """
+    gt_sorted = sorted(ground_truth.ayahs, key=lambda a: a.ayah_number)
+    res_sorted = sorted(results, key=lambda r: r.ayah.ayah_number)
+
+    gt_starts = [a.start_time for a in gt_sorted]
+    gt_ends = [a.end_time for a in gt_sorted]
+    pred_starts = [r.start_time for r in res_sorted]
+    pred_ends = [r.end_time for r in res_sorted]
+
+    return StrategyMetrics(
+        strategy=strategy,
+        surah_id=surah_id,
+        mae_start=compute_mae(pred_starts, gt_starts),
+        mae_end=compute_mae(pred_ends, gt_ends),
+        avg_similarity=compute_avg_similarity(results),
+        pct_high_confidence=compute_pct_high_confidence(results),
+        runtime_seconds=runtime_seconds,
+        ayah_count=len(results),
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )

--- a/munajjam/munajjam/benchmark/models.py
+++ b/munajjam/munajjam/benchmark/models.py
@@ -1,0 +1,57 @@
+"""
+Pydantic data models for the benchmark harness.
+
+Defines ground-truth, strategy metrics, and report structures.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class GroundTruthAyah(BaseModel):
+    """A single ayah with manually-verified timestamps."""
+
+    ayah_number: int = Field(..., ge=1)
+    start_time: float = Field(..., ge=0.0)
+    end_time: float = Field(..., ge=0.0)
+    text: str = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def end_after_start(self) -> GroundTruthAyah:
+        if self.end_time <= self.start_time:
+            msg = f"end_time ({self.end_time}) must be > start_time ({self.start_time})"
+            raise ValueError(msg)
+        return self
+
+
+class GroundTruthSurah(BaseModel):
+    """Ground-truth timestamps for one surah."""
+
+    surah_id: int = Field(..., ge=1, le=114)
+    reciter: str
+    audio_filename: str
+    ayahs: list[GroundTruthAyah]
+    notes: str | None = None
+
+
+class StrategyMetrics(BaseModel):
+    """Per-strategy benchmark results for one surah."""
+
+    strategy: str
+    surah_id: int = Field(..., ge=1, le=114)
+    mae_start: float = Field(..., ge=0.0)
+    mae_end: float = Field(..., ge=0.0)
+    avg_similarity: float = Field(..., ge=0.0, le=1.0)
+    pct_high_confidence: float = Field(..., ge=0.0, le=100.0)
+    runtime_seconds: float = Field(..., ge=0.0)
+    ayah_count: int = Field(..., ge=0)
+    timestamp: str
+
+
+class BenchmarkReport(BaseModel):
+    """Top-level container for all benchmark results."""
+
+    generated_at: str
+    munajjam_version: str
+    results: list[StrategyMetrics]

--- a/munajjam/munajjam/benchmark/runner.py
+++ b/munajjam/munajjam/benchmark/runner.py
@@ -1,0 +1,140 @@
+"""
+Benchmark runner for evaluating alignment strategies.
+
+Converts ground-truth data into Segments (no real transcriber needed),
+runs the Aligner with each strategy, and collects metrics.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import munajjam
+from munajjam.benchmark.loader import list_ground_truth_files, load_ground_truth
+from munajjam.benchmark.metrics import compute_strategy_metrics
+from munajjam.benchmark.models import (
+    BenchmarkReport,
+    GroundTruthSurah,
+    StrategyMetrics,
+)
+from munajjam.core.aligner import Aligner, AlignmentStrategy
+from munajjam.data import load_surah_ayahs
+from munajjam.models import Segment, SegmentType
+
+_DEFAULT_STRATEGIES = [
+    AlignmentStrategy.GREEDY,
+    AlignmentStrategy.DP,
+    AlignmentStrategy.HYBRID,
+]
+
+
+class BenchmarkRunner:
+    """Run alignment benchmarks against ground-truth data.
+
+    Converts ground-truth ayahs into Segment objects (using the
+    ground-truth text as perfectly-transcribed text), then runs
+    each configured alignment strategy and collects metrics.
+
+    No GPU, real audio, or transcriber is required.
+    """
+
+    def __init__(
+        self,
+        ground_truth_dir: Path,
+        results_dir: Path | None = None,
+        strategies: list[AlignmentStrategy] | None = None,
+    ) -> None:
+        self.ground_truth_dir = ground_truth_dir
+        self.results_dir = results_dir
+        self.strategies = strategies if strategies is not None else list(_DEFAULT_STRATEGIES)
+
+    def _ground_truth_to_segments(
+        self,
+        ground_truth: GroundTruthSurah,
+    ) -> list[Segment]:
+        """Convert ground-truth ayahs into Segment objects for alignment."""
+        return [
+            Segment(
+                id=i + 1,
+                surah_id=ground_truth.surah_id,
+                start=gt_ayah.start_time,
+                end=gt_ayah.end_time,
+                text=gt_ayah.text,
+                type=SegmentType.AYAH,
+            )
+            for i, gt_ayah in enumerate(
+                sorted(ground_truth.ayahs, key=lambda a: a.ayah_number),
+            )
+        ]
+
+    def run_surah(
+        self,
+        ground_truth: GroundTruthSurah,
+    ) -> list[StrategyMetrics]:
+        """Run all strategies on one surah and return metrics.
+
+        Args:
+            ground_truth: Ground-truth data for the surah.
+
+        Returns:
+            List of StrategyMetrics, one per strategy.
+        """
+        ayahs = load_surah_ayahs(ground_truth.surah_id)
+        segments = self._ground_truth_to_segments(ground_truth)
+        metrics_list: list[StrategyMetrics] = []
+
+        for strategy in self.strategies:
+            aligner = Aligner(
+                audio_path=ground_truth.audio_filename,
+                strategy=strategy,
+                energy_snap=False,
+            )
+            t0 = time.perf_counter()
+            results = aligner.align(segments, ayahs)
+            runtime = time.perf_counter() - t0
+
+            metrics = compute_strategy_metrics(
+                strategy=strategy.value,
+                surah_id=ground_truth.surah_id,
+                results=results,
+                ground_truth=ground_truth,
+                runtime_seconds=round(runtime, 6),
+            )
+            metrics_list.append(metrics)
+
+        return metrics_list
+
+    def run_all(self) -> BenchmarkReport:
+        """Load all ground-truth files and benchmark every strategy.
+
+        Returns:
+            BenchmarkReport containing all results.
+        """
+        gt_files = list_ground_truth_files(self.ground_truth_dir)
+        all_metrics: list[StrategyMetrics] = []
+        for gt_file in gt_files:
+            gt = load_ground_truth(gt_file)
+            all_metrics.extend(self.run_surah(gt))
+
+        return BenchmarkReport(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            munajjam_version=munajjam.__version__,
+            results=all_metrics,
+        )
+
+    def save_json(
+        self,
+        report: BenchmarkReport,
+        output_path: Path,
+    ) -> None:
+        """Write the benchmark report as JSON.
+
+        Creates parent directories if they do not exist.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            report.model_dump_json(indent=2),
+            encoding="utf-8",
+        )

--- a/tests/unit/test_benchmark_grumpy.py
+++ b/tests/unit/test_benchmark_grumpy.py
@@ -1,0 +1,1103 @@
+"""
+Adversarial / grumpy-tester tests for the benchmark harness (Issue #45).
+
+This file deliberately targets gaps in the existing test suite:
+- Boundary conditions the happy-path tests ignore
+- Model validation weaknesses (empty strings, whitespace-only text)
+- Numerical edge cases (NaN, infinity, very large values)
+- File-system edge cases (empty file, BOM, wrong JSON root type)
+- Loader behaviour with extra/missing fields
+- Leaderboard formatting with long strategy names and zero values
+- Runner behaviour with empty strategies list
+- Duplicate ayah numbers in ground truth
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from munajjam.benchmark.leaderboard import generate_leaderboard, save_leaderboard
+from munajjam.benchmark.loader import list_ground_truth_files, load_ground_truth
+from munajjam.benchmark.metrics import (
+    compute_avg_similarity,
+    compute_mae,
+    compute_pct_high_confidence,
+    compute_strategy_metrics,
+)
+from munajjam.benchmark.models import (
+    BenchmarkReport,
+    GroundTruthAyah,
+    GroundTruthSurah,
+    StrategyMetrics,
+)
+from munajjam.benchmark.runner import BenchmarkRunner
+from munajjam.models import AlignmentResult, Ayah
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ayah(
+    ayah_number: int = 1,
+    start_time: float = 0.0,
+    end_time: float = 5.0,
+    text: str = "بسم الله",
+) -> GroundTruthAyah:
+    return GroundTruthAyah(
+        ayah_number=ayah_number,
+        start_time=start_time,
+        end_time=end_time,
+        text=text,
+    )
+
+
+def _make_surah(
+    surah_id: int = 1,
+    ayahs: list[GroundTruthAyah] | None = None,
+) -> GroundTruthSurah:
+    if ayahs is None:
+        ayahs = [_make_ayah()]
+    return GroundTruthSurah(
+        surah_id=surah_id,
+        reciter="test",
+        audio_filename="001.wav",
+        ayahs=ayahs,
+    )
+
+
+def _make_result(
+    ayah_number: int,
+    start: float,
+    end: float,
+    similarity: float,
+    surah_id: int = 1,
+) -> AlignmentResult:
+    return AlignmentResult(
+        ayah=Ayah(
+            id=ayah_number,
+            surah_id=surah_id,
+            ayah_number=ayah_number,
+            text="test",
+        ),
+        start_time=start,
+        end_time=end,
+        transcribed_text="test",
+        similarity_score=similarity,
+    )
+
+
+def _make_strategy_metrics(**kwargs: object) -> StrategyMetrics:
+    defaults: dict[str, object] = {
+        "strategy": "greedy",
+        "surah_id": 1,
+        "mae_start": 0.1,
+        "mae_end": 0.2,
+        "avg_similarity": 0.9,
+        "pct_high_confidence": 80.0,
+        "runtime_seconds": 0.01,
+        "ayah_count": 7,
+        "timestamp": "2026-02-26T12:00:00+00:00",
+    }
+    defaults.update(kwargs)
+    return StrategyMetrics(**defaults)  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# MODEL VALIDATION - boundary and weakness tests
+# ===========================================================================
+
+
+class TestGroundTruthAyahBoundaries:
+    """Probe GroundTruthAyah for validation gaps the happy-path suite missed."""
+
+    def test_whitespace_only_text_is_accepted_by_pydantic(self) -> None:
+        """
+        A single space passes min_length=1 but is semantically meaningless.
+        This test documents the current behaviour. If the model is tightened
+        to reject whitespace-only text this test should be updated.
+        """
+        # This SHOULD ideally be rejected, but min_length=1 allows it.
+        # We document it as a known weakness.
+        ayah = GroundTruthAyah(
+            ayah_number=1,
+            start_time=0.0,
+            end_time=1.0,
+            text=" ",
+        )
+        assert ayah.text == " "
+
+    def test_minimum_positive_duration_is_accepted(self) -> None:
+        """end_time must be strictly > start_time; a tiny epsilon must pass."""
+        ayah = GroundTruthAyah(
+            ayah_number=1,
+            start_time=0.0,
+            end_time=1e-9,
+            text="بسم الله",
+        )
+        assert ayah.end_time > ayah.start_time
+
+    def test_very_large_timestamps_are_accepted(self) -> None:
+        """No upper bound on timestamps; a 24-hour audio file should be fine."""
+        ayah = GroundTruthAyah(
+            ayah_number=1,
+            start_time=86390.0,
+            end_time=86399.0,
+            text="بسم الله",
+        )
+        assert ayah.end_time > ayah.start_time
+
+    def test_ayah_number_at_maximum_reasonable_value(self) -> None:
+        """The longest surah (Al-Baqarah) has 286 ayahs; no upper cap on ayah_number."""
+        ayah = _make_ayah(ayah_number=286)
+        assert ayah.ayah_number == 286
+
+    def test_rejects_negative_end_time(self) -> None:
+        """Both start_time and end_time must be >= 0."""
+        with pytest.raises(ValidationError):
+            GroundTruthAyah(
+                ayah_number=1,
+                start_time=0.0,
+                end_time=-1.0,
+                text="بسم الله",
+            )
+
+
+class TestGroundTruthSurahBoundaries:
+    """Probe GroundTruthSurah for gaps."""
+
+    def test_surah_id_at_exact_upper_boundary_114(self) -> None:
+        """surah_id=114 is valid; the existing suite only tested 115 (rejection)."""
+        gt = _make_surah(surah_id=114)
+        assert gt.surah_id == 114
+
+    def test_surah_id_at_exact_lower_boundary_1(self) -> None:
+        gt = _make_surah(surah_id=1)
+        assert gt.surah_id == 1
+
+    def test_empty_ayahs_list_is_accepted(self) -> None:
+        """
+        GroundTruthSurah has no validator requiring at least one ayah.
+        This test documents the current behaviour - empty ayahs list is accepted.
+        """
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="001.wav",
+            ayahs=[],
+        )
+        assert gt.ayahs == []
+
+    def test_empty_reciter_string_is_accepted(self) -> None:
+        """
+        reciter field has no min_length constraint. Empty string is accepted.
+        This documents a potential data-quality gap.
+        """
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="",
+            audio_filename="001.wav",
+            ayahs=[_make_ayah()],
+        )
+        assert gt.reciter == ""
+
+    def test_empty_audio_filename_is_accepted(self) -> None:
+        """
+        audio_filename has no min_length or format constraint.
+        An empty string passes, which could cause downstream issues.
+        """
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="",
+            ayahs=[_make_ayah()],
+        )
+        assert gt.audio_filename == ""
+
+    def test_duplicate_ayah_numbers_are_not_rejected(self) -> None:
+        """
+        GroundTruthSurah has no validator rejecting duplicate ayah_number values.
+        Two ayahs with the same number can be inserted. This documents a known gap.
+        """
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="001.wav",
+            ayahs=[
+                _make_ayah(ayah_number=1, start_time=0.0, end_time=5.0),
+                _make_ayah(ayah_number=1, start_time=5.0, end_time=10.0),
+            ],
+        )
+        assert len(gt.ayahs) == 2
+
+    def test_notes_can_be_empty_string(self) -> None:
+        """notes='' is different from notes=None; both should work."""
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="001.wav",
+            ayahs=[_make_ayah()],
+            notes="",
+        )
+        assert gt.notes == ""
+
+    def test_arabic_unicode_in_reciter_is_preserved(self) -> None:
+        """Unicode reciter names must round-trip through the model."""
+        reciter_name = "محمود خليل الحصري"
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter=reciter_name,
+            audio_filename="001.wav",
+            ayahs=[_make_ayah()],
+        )
+        assert gt.reciter == reciter_name
+
+
+class TestStrategyMetricsBoundaries:
+    """Probe StrategyMetrics for validation edge cases."""
+
+    def test_empty_strategy_string_is_accepted(self) -> None:
+        """
+        strategy field has no min_length. An empty strategy name is accepted.
+        This documents a data-quality gap.
+        """
+        m = _make_strategy_metrics(strategy="")
+        assert m.strategy == ""
+
+    def test_runtime_seconds_exactly_zero(self) -> None:
+        """ge=0.0 means 0.0 should pass."""
+        m = _make_strategy_metrics(runtime_seconds=0.0)
+        assert m.runtime_seconds == 0.0
+
+    def test_ayah_count_exactly_zero(self) -> None:
+        """ge=0 means 0 should pass (empty run)."""
+        m = _make_strategy_metrics(ayah_count=0)
+        assert m.ayah_count == 0
+
+    def test_avg_similarity_exact_boundaries(self) -> None:
+        """Both 0.0 and 1.0 are valid boundary values."""
+        m_low = _make_strategy_metrics(avg_similarity=0.0)
+        m_high = _make_strategy_metrics(avg_similarity=1.0)
+        assert m_low.avg_similarity == 0.0
+        assert m_high.avg_similarity == 1.0
+
+    def test_pct_high_confidence_exact_boundaries(self) -> None:
+        """Both 0.0 and 100.0 are valid boundary values."""
+        m_low = _make_strategy_metrics(pct_high_confidence=0.0)
+        m_high = _make_strategy_metrics(pct_high_confidence=100.0)
+        assert m_low.pct_high_confidence == 0.0
+        assert m_high.pct_high_confidence == 100.0
+
+    def test_rejects_negative_runtime(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_strategy_metrics(runtime_seconds=-0.001)
+
+    def test_rejects_negative_ayah_count(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_strategy_metrics(ayah_count=-1)
+
+    def test_strategy_with_unicode_name(self) -> None:
+        """A Unicode strategy name must survive model round-trip."""
+        m = _make_strategy_metrics(strategy="استراتيجية")
+        assert m.strategy == "استراتيجية"
+
+    def test_strategy_metrics_json_round_trip_preserves_floats(self) -> None:
+        """Verify floating-point precision is not silently truncated during JSON serialization."""
+        m = _make_strategy_metrics(mae_start=0.123456789, mae_end=0.987654321)
+        restored = StrategyMetrics.model_validate_json(m.model_dump_json())
+        assert restored.mae_start == pytest.approx(0.123456789, rel=1e-9)
+        assert restored.mae_end == pytest.approx(0.987654321, rel=1e-9)
+
+
+class TestBenchmarkReportBoundaries:
+    """Probe BenchmarkReport for edge cases."""
+
+    def test_empty_results_list(self) -> None:
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[],
+        )
+        assert report.results == []
+
+    def test_unicode_in_version_string(self) -> None:
+        """Version strings are not constrained; unusual values must survive."""
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0-بيتا",
+            results=[],
+        )
+        assert "بيتا" in report.munajjam_version
+
+    def test_json_round_trip_with_empty_results(self) -> None:
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="2.0.0",
+            results=[],
+        )
+        restored = BenchmarkReport.model_validate_json(report.model_dump_json())
+        assert restored.results == []
+        assert restored.munajjam_version == "2.0.0"
+
+
+# ===========================================================================
+# METRIC COMPUTATION - numerical edge cases
+# ===========================================================================
+
+
+class TestComputeMaeNumericalEdges:
+    """Stress-test compute_mae with problematic numerical inputs."""
+
+    def test_nan_in_predicted_propagates(self) -> None:
+        """
+        NaN in predicted list causes compute_mae to return NaN.
+        The function performs no sanitisation. This test documents that
+        the function does NOT defend against NaN inputs.
+        """
+        result = compute_mae([float("nan"), 1.0], [1.0, 1.0])
+        assert math.isnan(result)
+
+    def test_nan_in_actual_propagates(self) -> None:
+        result = compute_mae([1.0, 1.0], [float("nan"), 1.0])
+        assert math.isnan(result)
+
+    def test_inf_in_predicted_propagates(self) -> None:
+        """Infinity in input produces infinity in output."""
+        result = compute_mae([float("inf"), 1.0], [1.0, 1.0])
+        assert math.isinf(result)
+
+    def test_very_large_floats_do_not_overflow(self) -> None:
+        """Python floats can represent up to ~1.8e308; this should not raise."""
+        large = 1e300
+        result = compute_mae([large], [0.0])
+        assert result == pytest.approx(large)
+
+    def test_negative_values_in_inputs(self) -> None:
+        """
+        compute_mae accepts any float list. Negative timestamps would be
+        invalid domain data, but the function itself applies no domain constraint.
+        |(-5.0) - (-3.0)| = 2.0
+        """
+        result = compute_mae([-5.0], [-3.0])
+        assert result == pytest.approx(2.0)
+
+    def test_mismatched_predicted_longer_than_actual(self) -> None:
+        """When predicted is longer, only first len(actual) pairs are used."""
+        # Only pair: |1.0 - 2.0| = 1.0; /1 = 1.0
+        result = compute_mae([1.0, 5.0, 9.0], [2.0])
+        assert result == pytest.approx(1.0)
+
+    def test_single_zero_delta(self) -> None:
+        """Perfect prediction at a single point gives exactly 0.0."""
+        result = compute_mae([42.0], [42.0])
+        assert result == 0.0
+
+
+class TestComputeAvgSimilarityEdges:
+    """Stress-test compute_avg_similarity."""
+
+    def test_single_result_at_zero_similarity(self) -> None:
+        results = [_make_result(1, 0.0, 1.0, 0.0)]
+        assert compute_avg_similarity(results) == pytest.approx(0.0)
+
+    def test_single_result_at_max_similarity(self) -> None:
+        results = [_make_result(1, 0.0, 1.0, 1.0)]
+        assert compute_avg_similarity(results) == pytest.approx(1.0)
+
+    def test_large_result_set_average_correctness(self) -> None:
+        """100 results all at 0.5 must average to exactly 0.5."""
+        results = [_make_result(i, float(i), float(i) + 1.0, 0.5) for i in range(1, 101)]
+        assert compute_avg_similarity(results) == pytest.approx(0.5)
+
+    def test_alternating_zero_and_one(self) -> None:
+        """50 zeros and 50 ones must average to 0.5."""
+        results = []
+        for i in range(1, 51):
+            results.append(_make_result(i, float(i), float(i) + 0.5, 0.0))
+        for i in range(51, 101):
+            results.append(_make_result(i, float(i), float(i) + 0.5, 1.0))
+        assert compute_avg_similarity(results) == pytest.approx(0.5)
+
+
+class TestComputePctHighConfidenceEdges:
+    """Stress-test compute_pct_high_confidence boundary conditions."""
+
+    def test_single_result_at_exact_0_8_is_high_confidence(self) -> None:
+        """is_high_confidence uses >=0.8; exactly 0.8 MUST be high confidence."""
+        results = [_make_result(1, 0.0, 1.0, 0.8)]
+        assert compute_pct_high_confidence(results) == pytest.approx(100.0)
+
+    def test_single_result_just_below_0_8(self) -> None:
+        """0.7999 must NOT be high confidence."""
+        results = [_make_result(1, 0.0, 1.0, 0.7999)]
+        assert compute_pct_high_confidence(results) == pytest.approx(0.0)
+
+    def test_single_result_at_zero_similarity(self) -> None:
+        results = [_make_result(1, 0.0, 1.0, 0.0)]
+        assert compute_pct_high_confidence(results) == pytest.approx(0.0)
+
+    def test_single_result_at_one_similarity(self) -> None:
+        results = [_make_result(1, 0.0, 1.0, 1.0)]
+        assert compute_pct_high_confidence(results) == pytest.approx(100.0)
+
+    def test_result_count_does_not_affect_percentage_math(self) -> None:
+        """1 out of 3 is 33.33...%; must not round to wrong value."""
+        results = [
+            _make_result(1, 0.0, 1.0, 0.9),  # high
+            _make_result(2, 1.0, 2.0, 0.5),  # low
+            _make_result(3, 2.0, 3.0, 0.3),  # low
+        ]
+        expected = (1 / 3) * 100.0
+        assert compute_pct_high_confidence(results) == pytest.approx(expected, rel=1e-6)
+
+
+class TestComputeStrategyMetricsEdges:
+    """Stress-test the assembly function."""
+
+    def test_more_results_than_ground_truth_ayahs(self) -> None:
+        """
+        compute_strategy_metrics calls compute_mae which uses min(len(p), len(a)).
+        Predicted list longer than GT must not raise; ayah_count should reflect
+        the actual number of results, not the GT count.
+        """
+        gt = _make_surah(ayahs=[
+            _make_ayah(ayah_number=1, start_time=0.0, end_time=5.0),
+        ])
+        results = [
+            _make_result(1, 0.1, 5.1, 0.9),
+            _make_result(2, 5.5, 10.0, 0.85),  # extra result beyond GT
+        ]
+        metrics = compute_strategy_metrics(
+            strategy="greedy",
+            surah_id=1,
+            results=results,
+            ground_truth=gt,
+            runtime_seconds=0.01,
+        )
+        # ayah_count is len(results), not len(gt.ayahs)
+        assert metrics.ayah_count == 2
+        # MAE only compared 1 pair (min of 2 predicted, 1 GT)
+        assert metrics.mae_start == pytest.approx(abs(0.1 - 0.0))
+
+    def test_more_ground_truth_than_results(self) -> None:
+        """Ground truth has 3 ayahs but only 1 result; MAE uses min=1 pair."""
+        gt = _make_surah(ayahs=[
+            _make_ayah(ayah_number=1, start_time=0.0, end_time=5.0),
+            _make_ayah(ayah_number=2, start_time=5.5, end_time=10.0),
+            _make_ayah(ayah_number=3, start_time=10.5, end_time=14.0),
+        ])
+        results = [_make_result(1, 0.0, 5.0, 0.9)]
+        metrics = compute_strategy_metrics(
+            strategy="dp",
+            surah_id=1,
+            results=results,
+            ground_truth=gt,
+            runtime_seconds=0.005,
+        )
+        assert metrics.ayah_count == 1
+        assert metrics.mae_start == pytest.approx(0.0)
+
+    def test_results_with_unsorted_ayah_numbers_are_sorted_before_comparison(self) -> None:
+        """
+        compute_strategy_metrics sorts both GT and results by ayah_number.
+        Results handed in backwards must produce the same MAE as sorted order.
+        """
+        gt = _make_surah(ayahs=[
+            _make_ayah(ayah_number=1, start_time=0.0, end_time=5.0),
+            _make_ayah(ayah_number=2, start_time=5.0, end_time=10.0),
+        ])
+        # Intentionally reversed
+        results_reversed = [
+            _make_result(2, 5.1, 10.1, 0.9),
+            _make_result(1, 0.1, 5.1, 0.85),
+        ]
+        results_sorted = [
+            _make_result(1, 0.1, 5.1, 0.85),
+            _make_result(2, 5.1, 10.1, 0.9),
+        ]
+        m_rev = compute_strategy_metrics("greedy", 1, results_reversed, gt, 0.01)
+        m_sorted = compute_strategy_metrics("greedy", 1, results_sorted, gt, 0.01)
+        assert m_rev.mae_start == pytest.approx(m_sorted.mae_start)
+        assert m_rev.mae_end == pytest.approx(m_sorted.mae_end)
+
+    def test_negative_runtime_raises_validation_error(self) -> None:
+        """
+        A negative runtime_seconds value must cause StrategyMetrics construction
+        to fail with a ValidationError (runtime_seconds has ge=0.0).
+        """
+        gt = _make_surah()
+        results = [_make_result(1, 0.0, 5.0, 0.9)]
+        with pytest.raises(ValidationError):
+            compute_strategy_metrics(
+                strategy="greedy",
+                surah_id=1,
+                results=results,
+                ground_truth=gt,
+                runtime_seconds=-1.0,
+            )
+
+
+# ===========================================================================
+# LOADER - file-system and encoding edge cases
+# ===========================================================================
+
+
+class TestLoadGroundTruthEdgeCases:
+    """File-system adversarial tests for load_ground_truth."""
+
+    def test_empty_file_raises(self, tmp_path: Path) -> None:
+        """An empty file is not valid JSON; must raise json.JSONDecodeError."""
+        gt_file = tmp_path / "empty.json"
+        gt_file.write_text("", encoding="utf-8")
+        with pytest.raises(Exception):  # json.JSONDecodeError
+            load_ground_truth(gt_file)
+
+    def test_json_null_root_raises(self, tmp_path: Path) -> None:
+        """A file containing only 'null' is valid JSON but fails Pydantic validation."""
+        gt_file = tmp_path / "null.json"
+        gt_file.write_text("null", encoding="utf-8")
+        with pytest.raises(Exception):
+            load_ground_truth(gt_file)
+
+    def test_json_array_root_raises(self, tmp_path: Path) -> None:
+        """A JSON array at root level must fail Pydantic validation (expects object)."""
+        gt_file = tmp_path / "array.json"
+        gt_file.write_text('[{"surah_id": 1}]', encoding="utf-8")
+        with pytest.raises(Exception):
+            load_ground_truth(gt_file)
+
+    def test_file_with_bom_is_loaded_correctly(self, tmp_path: Path) -> None:
+        """
+        A UTF-8 BOM (\ufeff) at the start of the file must not cause a parse error
+        because Python's open(encoding='utf-8') does NOT strip BOM automatically;
+        only 'utf-8-sig' does. This test verifies the current behaviour.
+        """
+        data = {
+            "surah_id": 1,
+            "reciter": "test",
+            "audio_filename": "001.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 5.0,
+                    "text": "بسم الله",
+                }
+            ],
+        }
+        gt_file = tmp_path / "bom.json"
+        # Write with BOM prefix manually
+        raw = "\ufeff" + json.dumps(data)
+        gt_file.write_bytes(raw.encode("utf-8-sig"))
+        # With utf-8 (not utf-8-sig) the BOM character leaks into the JSON string.
+        # json.loads will fail because the BOM makes the first character invalid.
+        # We just confirm this raises rather than silently corrupting data.
+        with pytest.raises(Exception):
+            load_ground_truth(gt_file)
+
+    def test_extra_fields_in_json_are_silently_ignored(self, tmp_path: Path) -> None:
+        """
+        Pydantic v2 by default ignores extra fields. Extra keys in the JSON
+        must not cause a validation error.
+        """
+        data = {
+            "surah_id": 1,
+            "reciter": "test",
+            "audio_filename": "001.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 5.0,
+                    "text": "بسم الله",
+                    "unexpected_field": "should be ignored",
+                }
+            ],
+            "completely_unknown_key": 42,
+        }
+        gt_file = tmp_path / "extra_fields.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+        result = load_ground_truth(gt_file)
+        assert result.surah_id == 1
+
+    def test_directory_path_raises_os_error(self, tmp_path: Path) -> None:
+        """
+        Passing a directory path instead of a file raises IsADirectoryError
+        (a subclass of OSError), NOT FileNotFoundError.  The docstring claims
+        FileNotFoundError but the real behaviour is IsADirectoryError because
+        path.exists() is True for directories, so the existence guard does not
+        trigger; the error surfaces when open() is called on a directory.
+
+        This test documents the gap between the docstring and reality.
+        """
+        with pytest.raises(OSError):
+            load_ground_truth(tmp_path)
+
+    def test_path_object_and_string_give_identical_results(self, tmp_path: Path) -> None:
+        """load_ground_truth must accept both Path and str and return equal results."""
+        data = {
+            "surah_id": 112,
+            "reciter": "test",
+            "audio_filename": "112.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 4.0,
+                    "text": "قل هو الله احد",
+                }
+            ],
+        }
+        gt_file = tmp_path / "surah_112.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+
+        via_path = load_ground_truth(gt_file)
+        via_str = load_ground_truth(str(gt_file))
+        assert via_path.model_dump() == via_str.model_dump()
+
+    def test_missing_required_field_raises(self, tmp_path: Path) -> None:
+        """JSON missing 'reciter' must cause a Pydantic ValidationError."""
+        data = {
+            "surah_id": 1,
+            "audio_filename": "001.wav",
+            "ayahs": [],
+        }
+        gt_file = tmp_path / "missing_field.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(Exception):  # ValidationError
+            load_ground_truth(gt_file)
+
+    def test_wrong_type_for_surah_id_raises(self, tmp_path: Path) -> None:
+        """surah_id as a string instead of int must fail validation."""
+        data = {
+            "surah_id": "one",
+            "reciter": "test",
+            "audio_filename": "001.wav",
+            "ayahs": [],
+        }
+        gt_file = tmp_path / "bad_type.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(Exception):
+            load_ground_truth(gt_file)
+
+
+class TestListGroundTruthFilesEdgeCases:
+    """Adversarial tests for list_ground_truth_files."""
+
+    def test_nonexistent_directory_raises(self, tmp_path: Path) -> None:
+        """list_ground_truth_files raises FileNotFoundError for nonexistent dirs."""
+        nonexistent = tmp_path / "does_not_exist"
+        with pytest.raises(FileNotFoundError, match="Ground truth directory not found"):
+            list_ground_truth_files(nonexistent)
+
+    def test_only_non_json_files_returns_empty(self, tmp_path: Path) -> None:
+        """A directory with only .txt files must return an empty list."""
+        (tmp_path / "readme.txt").write_text("ignore", encoding="utf-8")
+        (tmp_path / "data.csv").write_text("a,b", encoding="utf-8")
+        result = list_ground_truth_files(tmp_path)
+        assert result == []
+
+    def test_json_files_in_subdirectory_are_not_returned(self, tmp_path: Path) -> None:
+        """
+        list_ground_truth_files uses glob('*.json') which is NOT recursive.
+        Files in subdirectories must not appear in the result.
+        """
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (subdir / "nested.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "top_level.json").write_text("{}", encoding="utf-8")
+
+        result = list_ground_truth_files(tmp_path)
+        assert len(result) == 1
+        assert result[0].name == "top_level.json"
+
+    def test_result_is_sorted_lexicographically(self, tmp_path: Path) -> None:
+        """Files must be returned in sorted order regardless of filesystem ordering."""
+        names = ["surah_112.json", "surah_001.json", "surah_036.json", "surah_002.json"]
+        for name in names:
+            (tmp_path / name).write_text("{}", encoding="utf-8")
+
+        result = list_ground_truth_files(tmp_path)
+        assert [f.name for f in result] == sorted(names)
+
+    def test_single_json_file_returns_list_of_one(self, tmp_path: Path) -> None:
+        (tmp_path / "surah_001.json").write_text("{}", encoding="utf-8")
+        result = list_ground_truth_files(tmp_path)
+        assert len(result) == 1
+
+    def test_returns_path_objects(self, tmp_path: Path) -> None:
+        (tmp_path / "a.json").write_text("{}", encoding="utf-8")
+        result = list_ground_truth_files(tmp_path)
+        assert all(isinstance(p, Path) for p in result)
+
+
+# ===========================================================================
+# LEADERBOARD - formatting and content edge cases
+# ===========================================================================
+
+
+class TestLeaderboardEdgeCases:
+    """Adversarial tests for generate_leaderboard and save_leaderboard."""
+
+    def _make_single_strategy_report(
+        self,
+        strategy: str = "greedy",
+        surah_id: int = 1,
+    ) -> BenchmarkReport:
+        return BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[
+                _make_strategy_metrics(
+                    strategy=strategy,
+                    surah_id=surah_id,
+                    mae_start=0.1,
+                    mae_end=0.2,
+                    avg_similarity=0.9,
+                    pct_high_confidence=80.0,
+                    runtime_seconds=0.01,
+                    ayah_count=7,
+                )
+            ],
+        )
+
+    def test_single_strategy_report_has_one_surah_section(self) -> None:
+        report = self._make_single_strategy_report()
+        md = generate_leaderboard(report)
+        assert "## Surah 1" in md
+        assert "## Surah 2" not in md
+
+    def test_single_strategy_report_has_summary_section(self) -> None:
+        report = self._make_single_strategy_report()
+        md = generate_leaderboard(report)
+        assert "Overall Summary" in md
+
+    def test_strategy_name_longer_than_8_chars_does_not_crash(self) -> None:
+        """
+        _format_row uses '{strategy:<8}' which left-pads to 8 chars.
+        A name longer than 8 chars must not crash - it just exceeds the column width.
+        """
+        report = self._make_single_strategy_report(strategy="very_long_strategy_name")
+        md = generate_leaderboard(report)
+        assert "very_long_strategy_name" in md
+
+    def test_all_zero_metrics_renders_without_error(self) -> None:
+        """Zero values in every field must produce a valid Markdown string."""
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[
+                _make_strategy_metrics(
+                    mae_start=0.0,
+                    mae_end=0.0,
+                    avg_similarity=0.0,
+                    pct_high_confidence=0.0,
+                    runtime_seconds=0.0,
+                    ayah_count=0,
+                )
+            ],
+        )
+        md = generate_leaderboard(report)
+        assert isinstance(md, str)
+        assert len(md) > 0
+
+    def test_surah_114_appears_in_leaderboard(self) -> None:
+        """The last valid surah (114) must have its own section."""
+        report = self._make_single_strategy_report(surah_id=114)
+        md = generate_leaderboard(report)
+        assert "## Surah 114" in md
+
+    def test_multiple_strategies_single_surah_summary_averages_correctly(self) -> None:
+        """
+        The overall summary averages metrics per strategy across surahs.
+        With two strategies on one surah, each strategy appears once in the summary.
+        """
+        results = [
+            _make_strategy_metrics(strategy="greedy", surah_id=1, mae_start=0.2),
+            _make_strategy_metrics(strategy="dp", surah_id=1, mae_start=0.1),
+        ]
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=results,
+        )
+        md = generate_leaderboard(report)
+        assert "greedy" in md
+        assert "dp" in md
+
+    def test_same_mae_start_tie_is_handled_without_error(self) -> None:
+        """Two strategies with identical MAE start must not crash the sort."""
+        results = [
+            _make_strategy_metrics(strategy="greedy", surah_id=1, mae_start=0.1),
+            _make_strategy_metrics(strategy="dp", surah_id=1, mae_start=0.1),
+        ]
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=results,
+        )
+        md = generate_leaderboard(report)
+        assert "greedy" in md
+        assert "dp" in md
+
+    def test_generated_at_appears_in_output(self) -> None:
+        report = self._make_single_strategy_report()
+        md = generate_leaderboard(report)
+        assert "2026-02-26T12:00:00+00:00" in md
+
+    def test_save_leaderboard_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """save_leaderboard must silently overwrite an existing file."""
+        report = self._make_single_strategy_report()
+        output_path = tmp_path / "LEADERBOARD.md"
+        output_path.write_text("old content", encoding="utf-8")
+
+        save_leaderboard(report, output_path)
+
+        content = output_path.read_text(encoding="utf-8")
+        assert "old content" not in content
+        assert "Munajjam" in content
+
+    def test_save_leaderboard_creates_deeply_nested_dirs(self, tmp_path: Path) -> None:
+        """Parent dirs three levels deep must be created automatically."""
+        report = self._make_single_strategy_report()
+        output_path = tmp_path / "a" / "b" / "c" / "LEADERBOARD.md"
+        save_leaderboard(report, output_path)
+        assert output_path.exists()
+
+    def test_very_large_mae_value_renders_without_crashing(self) -> None:
+        """Unrealistically large MAE values must not crash the format string."""
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[
+                _make_strategy_metrics(
+                    mae_start=99999.999,
+                    mae_end=88888.888,
+                    runtime_seconds=3600.0,
+                    ayah_count=6236,
+                )
+            ],
+        )
+        md = generate_leaderboard(report)
+        assert "99999.999" in md
+
+    def test_leaderboard_output_contains_table_separator_row(self) -> None:
+        """Each table must contain the Markdown separator line '|---|'."""
+        report = self._make_single_strategy_report()
+        md = generate_leaderboard(report)
+        assert "|---" in md
+
+
+# ===========================================================================
+# RUNNER - configuration edge cases
+# ===========================================================================
+
+
+class TestBenchmarkRunnerEdgeCases:
+    """Adversarial tests for BenchmarkRunner."""
+
+    def test_empty_strategies_list_produces_no_metrics(
+        self, tmp_path: Path
+    ) -> None:
+        """strategies=[] should produce zero metrics (no strategies to run)."""
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            strategies=[],
+        )
+        gt = _make_surah()
+        metrics = runner.run_surah(gt)
+        assert len(metrics) == 0
+
+    def test_empty_strategies_list_run_all_produces_empty_report(
+        self, tmp_path: Path
+    ) -> None:
+        """strategies=[] through run_all should produce zero results."""
+        gt_dir = tmp_path / "gt"
+        gt_dir.mkdir()
+        data = {
+            "surah_id": 1,
+            "reciter": "test",
+            "audio_filename": "001.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 5.0,
+                    "text": "بسم الله",
+                }
+            ],
+        }
+        (gt_dir / "surah_001.json").write_text(json.dumps(data), encoding="utf-8")
+
+        runner = BenchmarkRunner(
+            ground_truth_dir=gt_dir,
+            strategies=[],
+        )
+        report = runner.run_all()
+        assert isinstance(report, BenchmarkReport)
+        assert len(report.results) == 0
+
+    def test_save_json_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """save_json must silently overwrite a previously written file."""
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[_make_strategy_metrics()],
+        )
+        output_path = tmp_path / "results.json"
+        runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+
+        runner.save_json(report, output_path)
+        # Write a second report with different version
+        report2 = BenchmarkReport(
+            generated_at="2026-02-26T13:00:00+00:00",
+            munajjam_version="2.0.0",
+            results=[],
+        )
+        runner.save_json(report2, output_path)
+        second_content = output_path.read_text(encoding="utf-8")
+
+        assert "2.0.0" in second_content
+        assert "1.0.0" not in second_content
+
+    def test_save_json_output_is_valid_json(self, tmp_path: Path) -> None:
+        """The file written by save_json must be parseable by standard json.loads."""
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[_make_strategy_metrics()],
+        )
+        output_path = tmp_path / "report.json"
+        runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+        runner.save_json(report, output_path)
+
+        raw = output_path.read_text(encoding="utf-8")
+        parsed = json.loads(raw)
+        assert parsed["munajjam_version"] == "1.0.0"
+        assert "results" in parsed
+
+    def test_ground_truth_to_segments_with_empty_ayahs(self, tmp_path: Path) -> None:
+        """
+        _ground_truth_to_segments must return an empty list (not raise) when
+        the ground truth has no ayahs.
+        """
+        runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="001.wav",
+            ayahs=[],
+        )
+        segments = runner._ground_truth_to_segments(gt)
+        assert segments == []
+
+    def test_results_dir_none_does_not_affect_run_all(self, tmp_path: Path) -> None:
+        """
+        results_dir=None is a valid configuration. run_all must not fail
+        solely because results_dir is not set (save_json is separate).
+        """
+        gt_dir = tmp_path / "gt"
+        gt_dir.mkdir()
+        runner = BenchmarkRunner(
+            ground_truth_dir=gt_dir,
+            results_dir=None,
+            strategies=[],
+        )
+        report = runner.run_all()
+        assert isinstance(report, BenchmarkReport)
+
+    def test_save_json_creates_deeply_nested_parent_dirs(self, tmp_path: Path) -> None:
+        """save_json must create arbitrarily deep parent directories."""
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="1.0.0",
+            results=[],
+        )
+        output_path = tmp_path / "a" / "b" / "c" / "results.json"
+        runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+        runner.save_json(report, output_path)
+        assert output_path.exists()
+
+    def test_single_ayah_ground_truth_to_segments(self, tmp_path: Path) -> None:
+        """A single-ayah ground truth produces exactly one segment with id=1."""
+        runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+        gt = _make_surah(ayahs=[_make_ayah(ayah_number=1)])
+        segments = runner._ground_truth_to_segments(gt)
+        assert len(segments) == 1
+        assert segments[0].id == 1
+
+    def test_segment_ids_are_sequential_from_one(self, tmp_path: Path) -> None:
+        """
+        Segment IDs are assigned as enumerate(sorted_ayahs)+1 regardless of
+        the original ayah_number values.
+        """
+        runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+        gt = _make_surah(ayahs=[
+            _make_ayah(ayah_number=5, start_time=0.0, end_time=5.0),
+            _make_ayah(ayah_number=3, start_time=5.0, end_time=10.0),
+            _make_ayah(ayah_number=1, start_time=10.0, end_time=15.0),
+        ])
+        segments = runner._ground_truth_to_segments(gt)
+        # Sorted by ayah_number: 1, 3, 5 -> ids 1, 2, 3
+        assert [s.id for s in segments] == [1, 2, 3]
+        # Text ordering should match ayah_number sort order
+        assert segments[0].start == 10.0  # ayah_number=1
+
+
+# ===========================================================================
+# FILE-SYSTEM PERMISSION TESTS (skip when running as root)
+# ===========================================================================
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="Root bypasses permission checks")
+class TestFilePermissions:
+    """Tests that require non-root execution to verify permission enforcement."""
+
+    def test_load_ground_truth_unreadable_file_raises(self, tmp_path: Path) -> None:
+        """A file with mode 000 must raise PermissionError or OSError."""
+        gt_file = tmp_path / "no_read.json"
+        data = {
+            "surah_id": 1,
+            "reciter": "test",
+            "audio_filename": "001.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 5.0,
+                    "text": "بسم الله",
+                }
+            ],
+        }
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+        gt_file.chmod(0o000)
+        try:
+            with pytest.raises((PermissionError, OSError)):
+                load_ground_truth(gt_file)
+        finally:
+            gt_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    def test_save_json_to_read_only_dir_raises(self, tmp_path: Path) -> None:
+        """Writing to a read-only directory must raise PermissionError or OSError."""
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o555)
+        try:
+            report = BenchmarkReport(
+                generated_at="2026-02-26T12:00:00+00:00",
+                munajjam_version="1.0.0",
+                results=[],
+            )
+            runner = BenchmarkRunner(ground_truth_dir=tmp_path)
+            with pytest.raises((PermissionError, OSError)):
+                runner.save_json(report, readonly_dir / "results.json")
+        finally:
+            readonly_dir.chmod(stat.S_IRWXU)

--- a/tests/unit/test_benchmark_leaderboard.py
+++ b/tests/unit/test_benchmark_leaderboard.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for benchmark leaderboard generation (Issue #45).
+
+Tests cover:
+- generate_leaderboard produces valid Markdown
+- Sections for each surah and overall summary
+- Rows sorted by MAE ascending within each surah
+- save_leaderboard writes file
+"""
+
+import pytest
+
+from munajjam.benchmark.leaderboard import generate_leaderboard, save_leaderboard
+from munajjam.benchmark.models import BenchmarkReport, StrategyMetrics
+
+
+def _make_report() -> BenchmarkReport:
+    """Create a fixture BenchmarkReport with 2 surahs x 3 strategies."""
+    results = []
+    for surah_id in (1, 112):
+        for strategy, mae in [("hybrid", 0.05), ("greedy", 0.15), ("dp", 0.10)]:
+            results.append(
+                StrategyMetrics(
+                    strategy=strategy,
+                    surah_id=surah_id,
+                    mae_start=mae,
+                    mae_end=mae + 0.05,
+                    avg_similarity=0.95 if strategy == "hybrid" else 0.90,
+                    pct_high_confidence=90.0 if strategy == "hybrid" else 80.0,
+                    runtime_seconds=0.01 * (surah_id + 1),
+                    ayah_count=7 if surah_id == 1 else 4,
+                    timestamp="2026-02-26T12:00:00+00:00",
+                )
+            )
+    return BenchmarkReport(
+        generated_at="2026-02-26T12:00:00+00:00",
+        munajjam_version="2.0.0a1",
+        results=results,
+    )
+
+
+class TestGenerateLeaderboard:
+    """Test Markdown leaderboard generation."""
+
+    def test_contains_header(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert "# Munajjam Alignment Benchmark Leaderboard" in md
+
+    def test_contains_version(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert "2.0.0a1" in md
+
+    def test_contains_surah_sections(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert "## Surah 1" in md
+        assert "## Surah 112" in md
+
+    def test_contains_overall_summary(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert "Overall Summary" in md
+
+    def test_contains_all_strategies(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert "greedy" in md
+        assert "dp" in md
+        assert "hybrid" in md
+
+    def test_contains_table_header(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert "MAE Start" in md
+        assert "MAE End" in md
+        assert "Avg Similarity" in md
+        assert "High Confidence" in md
+        assert "Runtime" in md
+
+    def test_rows_sorted_by_mae_start_ascending(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        # Within Surah 1 section, hybrid (0.05) should come before dp (0.10) before greedy (0.15)
+        lines = md.split("\n")
+        surah_1_lines = []
+        in_surah_1 = False
+        for line in lines:
+            if line.strip() == "## Surah 1":
+                in_surah_1 = True
+                continue
+            if in_surah_1 and line.startswith("## "):
+                break
+            if in_surah_1 and line.startswith("|") and ("hybrid" in line or "dp" in line or "greedy" in line):
+                surah_1_lines.append(line)
+        # hybrid should appear before dp, dp before greedy
+        strategy_order = []
+        for line in surah_1_lines:
+            if "hybrid" in line:
+                strategy_order.append("hybrid")
+            elif "dp" in line:
+                strategy_order.append("dp")
+            elif "greedy" in line:
+                strategy_order.append("greedy")
+        assert strategy_order == ["hybrid", "dp", "greedy"]
+
+    def test_empty_report(self) -> None:
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="2.0.0a1",
+            results=[],
+        )
+        md = generate_leaderboard(report)
+        assert "# Munajjam Alignment Benchmark Leaderboard" in md
+        # No surah sections, but summary section should still be present
+        assert "Overall Summary" in md
+
+    def test_returns_string(self) -> None:
+        report = _make_report()
+        md = generate_leaderboard(report)
+        assert isinstance(md, str)
+
+
+class TestSaveLeaderboard:
+    """Test save_leaderboard writes file."""
+
+    def test_writes_markdown_file(self, tmp_path) -> None:
+        report = _make_report()
+        output_path = tmp_path / "LEADERBOARD.md"
+        save_leaderboard(report, output_path)
+        assert output_path.exists()
+        content = output_path.read_text(encoding="utf-8")
+        assert "# Munajjam Alignment Benchmark Leaderboard" in content
+
+    def test_creates_parent_directories(self, tmp_path) -> None:
+        report = _make_report()
+        output_path = tmp_path / "nested" / "dir" / "LEADERBOARD.md"
+        save_leaderboard(report, output_path)
+        assert output_path.exists()

--- a/tests/unit/test_benchmark_loader.py
+++ b/tests/unit/test_benchmark_loader.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for benchmark ground-truth loader (Issue #45).
+
+Tests cover:
+- load_ground_truth with valid JSON file
+- load_ground_truth with nonexistent path
+- load_ground_truth with malformed JSON
+- list_ground_truth_files with multiple files
+"""
+
+import json
+
+import pytest
+
+from munajjam.benchmark.loader import list_ground_truth_files, load_ground_truth
+from munajjam.benchmark.models import GroundTruthSurah
+
+
+class TestLoadGroundTruth:
+    """Test load_ground_truth function."""
+
+    def test_loads_valid_json(self, tmp_path) -> None:
+        data = {
+            "surah_id": 1,
+            "reciter": "sample",
+            "audio_filename": "001.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 5.0,
+                    "text": "بسم الله",
+                },
+            ],
+        }
+        gt_file = tmp_path / "surah_001.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+
+        result = load_ground_truth(gt_file)
+        assert isinstance(result, GroundTruthSurah)
+        assert result.surah_id == 1
+        assert len(result.ayahs) == 1
+
+    def test_raises_file_not_found(self, tmp_path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_ground_truth(tmp_path / "nonexistent.json")
+
+    def test_raises_on_malformed_json(self, tmp_path) -> None:
+        gt_file = tmp_path / "bad.json"
+        gt_file.write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(Exception):  # json.JSONDecodeError
+            load_ground_truth(gt_file)
+
+    def test_raises_on_invalid_data(self, tmp_path) -> None:
+        """Valid JSON but fails Pydantic validation."""
+        data = {"surah_id": 999, "reciter": "x", "audio_filename": "x.wav", "ayahs": []}
+        gt_file = tmp_path / "invalid.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+        with pytest.raises(Exception):  # ValidationError
+            load_ground_truth(gt_file)
+
+    def test_accepts_string_path(self, tmp_path) -> None:
+        data = {
+            "surah_id": 112,
+            "reciter": "test",
+            "audio_filename": "112.wav",
+            "ayahs": [
+                {
+                    "ayah_number": 1,
+                    "start_time": 0.0,
+                    "end_time": 4.0,
+                    "text": "قل هو الله احد",
+                },
+            ],
+        }
+        gt_file = tmp_path / "surah_112.json"
+        gt_file.write_text(json.dumps(data), encoding="utf-8")
+
+        result = load_ground_truth(str(gt_file))
+        assert result.surah_id == 112
+
+
+class TestListGroundTruthFiles:
+    """Test list_ground_truth_files function."""
+
+    def test_returns_sorted_json_files(self, tmp_path) -> None:
+        (tmp_path / "surah_112.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "surah_001.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "readme.txt").write_text("ignore", encoding="utf-8")
+
+        files = list_ground_truth_files(tmp_path)
+        assert len(files) == 2
+        assert files[0].name == "surah_001.json"
+        assert files[1].name == "surah_112.json"
+
+    def test_empty_directory(self, tmp_path) -> None:
+        files = list_ground_truth_files(tmp_path)
+        assert files == []

--- a/tests/unit/test_benchmark_metrics.py
+++ b/tests/unit/test_benchmark_metrics.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for benchmark metric computation (Issue #45).
+
+Tests cover:
+- compute_mae with identical, offset, empty, and mismatched lists
+- compute_avg_similarity with known scores
+- compute_pct_high_confidence with all/none/mixed high-confidence
+- compute_strategy_metrics assembly function
+"""
+
+import pytest
+
+from munajjam.benchmark.metrics import (
+    compute_avg_similarity,
+    compute_mae,
+    compute_pct_high_confidence,
+    compute_strategy_metrics,
+)
+from munajjam.benchmark.models import GroundTruthAyah, GroundTruthSurah
+from munajjam.models import AlignmentResult, Ayah
+
+
+def _make_result(
+    ayah_number: int,
+    start: float,
+    end: float,
+    similarity: float,
+) -> AlignmentResult:
+    """Helper to create an AlignmentResult with minimal boilerplate."""
+    return AlignmentResult(
+        ayah=Ayah(id=ayah_number, surah_id=1, ayah_number=ayah_number, text="test"),
+        start_time=start,
+        end_time=end,
+        transcribed_text="test",
+        similarity_score=similarity,
+    )
+
+
+class TestComputeMae:
+    """Test mean absolute error computation."""
+
+    def test_identical_lists(self) -> None:
+        assert compute_mae([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == 0.0
+
+    def test_known_offset(self) -> None:
+        # |1.0-1.5| + |2.0-2.5| = 0.5 + 0.5 = 1.0, / 2 = 0.5
+        assert compute_mae([1.0, 2.0], [1.5, 2.5]) == pytest.approx(0.5)
+
+    def test_empty_predicted(self) -> None:
+        assert compute_mae([], [1.0, 2.0]) == 0.0
+
+    def test_empty_actual(self) -> None:
+        assert compute_mae([1.0, 2.0], []) == 0.0
+
+    def test_both_empty(self) -> None:
+        assert compute_mae([], []) == 0.0
+
+    def test_mismatched_lengths_uses_min(self) -> None:
+        # Only compare first 2 pairs: |1.0-1.1| + |2.0-2.2| = 0.1 + 0.2 = 0.3 / 2 = 0.15
+        result = compute_mae([1.0, 2.0, 3.0], [1.1, 2.2])
+        assert result == pytest.approx(0.15)
+
+    def test_single_element(self) -> None:
+        assert compute_mae([5.0], [3.0]) == pytest.approx(2.0)
+
+
+class TestComputeAvgSimilarity:
+    """Test average similarity computation."""
+
+    def test_empty_results(self) -> None:
+        assert compute_avg_similarity([]) == 0.0
+
+    def test_known_scores(self) -> None:
+        results = [
+            _make_result(1, 0.0, 5.0, 0.9),
+            _make_result(2, 5.0, 10.0, 0.8),
+        ]
+        assert compute_avg_similarity(results) == pytest.approx(0.85)
+
+    def test_single_result(self) -> None:
+        results = [_make_result(1, 0.0, 5.0, 0.95)]
+        assert compute_avg_similarity(results) == pytest.approx(0.95)
+
+    def test_all_perfect(self) -> None:
+        results = [_make_result(i, 0.0, 1.0, 1.0) for i in range(1, 6)]
+        assert compute_avg_similarity(results) == pytest.approx(1.0)
+
+
+class TestComputePctHighConfidence:
+    """Test percentage high-confidence computation."""
+
+    def test_empty_results(self) -> None:
+        assert compute_pct_high_confidence([]) == 0.0
+
+    def test_all_high_confidence(self) -> None:
+        # is_high_confidence = similarity_score >= 0.8
+        results = [_make_result(i, 0.0, 1.0, 0.9) for i in range(1, 4)]
+        assert compute_pct_high_confidence(results) == pytest.approx(100.0)
+
+    def test_none_high_confidence(self) -> None:
+        results = [_make_result(i, 0.0, 1.0, 0.5) for i in range(1, 4)]
+        assert compute_pct_high_confidence(results) == pytest.approx(0.0)
+
+    def test_mixed(self) -> None:
+        results = [
+            _make_result(1, 0.0, 1.0, 0.9),  # high
+            _make_result(2, 1.0, 2.0, 0.5),  # low
+            _make_result(3, 2.0, 3.0, 0.85),  # high
+            _make_result(4, 3.0, 4.0, 0.7),  # low
+        ]
+        assert compute_pct_high_confidence(results) == pytest.approx(50.0)
+
+    def test_boundary_at_0_8(self) -> None:
+        """Exactly 0.8 should be high confidence."""
+        results = [_make_result(1, 0.0, 1.0, 0.8)]
+        assert compute_pct_high_confidence(results) == pytest.approx(100.0)
+
+    def test_just_below_0_8(self) -> None:
+        """0.79 should NOT be high confidence."""
+        results = [_make_result(1, 0.0, 1.0, 0.79)]
+        assert compute_pct_high_confidence(results) == pytest.approx(0.0)
+
+
+class TestComputeStrategyMetrics:
+    """Test the assembly function that computes all metrics."""
+
+    def test_produces_valid_strategy_metrics(self) -> None:
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="test.wav",
+            ayahs=[
+                GroundTruthAyah(ayah_number=1, start_time=0.0, end_time=5.0, text="a"),
+                GroundTruthAyah(ayah_number=2, start_time=5.5, end_time=10.0, text="b"),
+            ],
+        )
+        results = [
+            _make_result(1, 0.1, 5.2, 0.95),
+            _make_result(2, 5.3, 10.1, 0.85),
+        ]
+        metrics = compute_strategy_metrics(
+            strategy="greedy",
+            surah_id=1,
+            results=results,
+            ground_truth=gt,
+            runtime_seconds=0.042,
+        )
+        assert metrics.strategy == "greedy"
+        assert metrics.surah_id == 1
+        assert metrics.mae_start == pytest.approx(0.15, abs=0.01)
+        assert metrics.mae_end == pytest.approx(0.15, abs=0.01)
+        assert metrics.avg_similarity == pytest.approx(0.9)
+        assert metrics.pct_high_confidence == pytest.approx(100.0)
+        assert metrics.runtime_seconds == pytest.approx(0.042)
+        assert metrics.ayah_count == 2
+        assert metrics.timestamp  # non-empty
+
+    def test_empty_results(self) -> None:
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="test.wav",
+            ayahs=[
+                GroundTruthAyah(ayah_number=1, start_time=0.0, end_time=5.0, text="a"),
+            ],
+        )
+        metrics = compute_strategy_metrics(
+            strategy="dp",
+            surah_id=1,
+            results=[],
+            ground_truth=gt,
+            runtime_seconds=0.01,
+        )
+        assert metrics.mae_start == 0.0
+        assert metrics.avg_similarity == 0.0
+        assert metrics.ayah_count == 0

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for benchmark data models (Issue #45).
+
+Tests cover:
+- GroundTruthAyah creation and validation
+- GroundTruthSurah creation with nested ayahs
+- StrategyMetrics validation
+- BenchmarkReport JSON round-trip
+"""
+
+import pytest
+
+from munajjam.benchmark.models import (
+    BenchmarkReport,
+    GroundTruthAyah,
+    GroundTruthSurah,
+    StrategyMetrics,
+)
+
+
+class TestGroundTruthAyah:
+    """Test GroundTruthAyah model."""
+
+    def test_valid_creation(self) -> None:
+        ayah = GroundTruthAyah(
+            ayah_number=1,
+            start_time=5.72,
+            end_time=9.74,
+            text="بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+        )
+        assert ayah.ayah_number == 1
+        assert ayah.start_time == 5.72
+        assert ayah.end_time == 9.74
+
+    def test_rejects_negative_start_time(self) -> None:
+        with pytest.raises(ValueError):
+            GroundTruthAyah(
+                ayah_number=1,
+                start_time=-1.0,
+                end_time=5.0,
+                text="بسم الله",
+            )
+
+    def test_rejects_zero_ayah_number(self) -> None:
+        with pytest.raises(ValueError):
+            GroundTruthAyah(
+                ayah_number=0,
+                start_time=0.0,
+                end_time=5.0,
+                text="بسم الله",
+            )
+
+    def test_rejects_empty_text(self) -> None:
+        with pytest.raises(ValueError):
+            GroundTruthAyah(
+                ayah_number=1,
+                start_time=0.0,
+                end_time=5.0,
+                text="",
+            )
+
+    def test_rejects_end_before_start(self) -> None:
+        with pytest.raises(ValueError, match="end_time.*must be > start_time"):
+            GroundTruthAyah(
+                ayah_number=1,
+                start_time=5.0,
+                end_time=1.0,
+                text="بسم الله",
+            )
+
+    def test_rejects_equal_start_end(self) -> None:
+        with pytest.raises(ValueError, match="end_time.*must be > start_time"):
+            GroundTruthAyah(
+                ayah_number=1,
+                start_time=5.0,
+                end_time=5.0,
+                text="بسم الله",
+            )
+
+
+class TestGroundTruthSurah:
+    """Test GroundTruthSurah model."""
+
+    def test_valid_creation(self) -> None:
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="sample",
+            audio_filename="001.wav",
+            ayahs=[
+                GroundTruthAyah(
+                    ayah_number=1,
+                    start_time=0.0,
+                    end_time=5.0,
+                    text="بسم الله",
+                ),
+            ],
+        )
+        assert gt.surah_id == 1
+        assert len(gt.ayahs) == 1
+        assert gt.notes is None
+
+    def test_rejects_invalid_surah_id(self) -> None:
+        with pytest.raises(ValueError):
+            GroundTruthSurah(
+                surah_id=0,
+                reciter="test",
+                audio_filename="test.wav",
+                ayahs=[
+                    GroundTruthAyah(
+                        ayah_number=1,
+                        start_time=0.0,
+                        end_time=5.0,
+                        text="test",
+                    ),
+                ],
+            )
+
+    def test_rejects_surah_id_above_114(self) -> None:
+        with pytest.raises(ValueError):
+            GroundTruthSurah(
+                surah_id=115,
+                reciter="test",
+                audio_filename="test.wav",
+                ayahs=[
+                    GroundTruthAyah(
+                        ayah_number=1,
+                        start_time=0.0,
+                        end_time=5.0,
+                        text="test",
+                    ),
+                ],
+            )
+
+    def test_optional_notes(self) -> None:
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="sample",
+            audio_filename="001.wav",
+            ayahs=[
+                GroundTruthAyah(
+                    ayah_number=1,
+                    start_time=0.0,
+                    end_time=5.0,
+                    text="بسم الله",
+                ),
+            ],
+            notes="Test notes",
+        )
+        assert gt.notes == "Test notes"
+
+
+class TestStrategyMetrics:
+    """Test StrategyMetrics model."""
+
+    def test_valid_creation(self) -> None:
+        m = StrategyMetrics(
+            strategy="greedy",
+            surah_id=1,
+            mae_start=0.15,
+            mae_end=0.20,
+            avg_similarity=0.95,
+            pct_high_confidence=85.7,
+            runtime_seconds=0.042,
+            ayah_count=7,
+            timestamp="2026-02-26T12:00:00+00:00",
+        )
+        assert m.strategy == "greedy"
+        assert m.mae_start == 0.15
+        assert m.pct_high_confidence == 85.7
+
+    def test_rejects_negative_mae(self) -> None:
+        with pytest.raises(ValueError):
+            StrategyMetrics(
+                strategy="greedy",
+                surah_id=1,
+                mae_start=-0.1,
+                mae_end=0.0,
+                avg_similarity=0.9,
+                pct_high_confidence=80.0,
+                runtime_seconds=0.01,
+                ayah_count=7,
+                timestamp="2026-02-26T12:00:00+00:00",
+            )
+
+    def test_rejects_similarity_above_one(self) -> None:
+        with pytest.raises(ValueError):
+            StrategyMetrics(
+                strategy="dp",
+                surah_id=1,
+                mae_start=0.0,
+                mae_end=0.0,
+                avg_similarity=1.1,
+                pct_high_confidence=100.0,
+                runtime_seconds=0.01,
+                ayah_count=7,
+                timestamp="2026-02-26T12:00:00+00:00",
+            )
+
+    def test_rejects_pct_above_100(self) -> None:
+        with pytest.raises(ValueError):
+            StrategyMetrics(
+                strategy="hybrid",
+                surah_id=1,
+                mae_start=0.0,
+                mae_end=0.0,
+                avg_similarity=0.9,
+                pct_high_confidence=100.1,
+                runtime_seconds=0.01,
+                ayah_count=7,
+                timestamp="2026-02-26T12:00:00+00:00",
+            )
+
+
+class TestBenchmarkReport:
+    """Test BenchmarkReport model."""
+
+    def test_valid_creation(self) -> None:
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="2.0.0a1",
+            results=[],
+        )
+        assert report.munajjam_version == "2.0.0a1"
+        assert report.results == []
+
+    def test_json_round_trip(self) -> None:
+        metrics = StrategyMetrics(
+            strategy="greedy",
+            surah_id=1,
+            mae_start=0.15,
+            mae_end=0.20,
+            avg_similarity=0.95,
+            pct_high_confidence=85.7,
+            runtime_seconds=0.042,
+            ayah_count=7,
+            timestamp="2026-02-26T12:00:00+00:00",
+        )
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="2.0.0a1",
+            results=[metrics],
+        )
+        json_str = report.model_dump_json()
+        restored = BenchmarkReport.model_validate_json(json_str)
+        assert restored.results[0].strategy == "greedy"
+        assert restored.results[0].mae_start == 0.15
+
+    def test_report_with_multiple_results(self) -> None:
+        results = [
+            StrategyMetrics(
+                strategy=s,
+                surah_id=1,
+                mae_start=0.1,
+                mae_end=0.2,
+                avg_similarity=0.9,
+                pct_high_confidence=80.0,
+                runtime_seconds=0.01,
+                ayah_count=7,
+                timestamp="2026-02-26T12:00:00+00:00",
+            )
+            for s in ("greedy", "dp", "hybrid")
+        ]
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="2.0.0a1",
+            results=results,
+        )
+        assert len(report.results) == 3

--- a/tests/unit/test_benchmark_runner.py
+++ b/tests/unit/test_benchmark_runner.py
@@ -1,0 +1,224 @@
+"""
+Unit tests for benchmark runner (Issue #45).
+
+Tests cover:
+- BenchmarkRunner.run_surah produces StrategyMetrics per strategy
+- BenchmarkRunner._ground_truth_to_segments conversion
+- BenchmarkRunner.run_all with fixture files
+- BenchmarkRunner.save_json round-trip
+"""
+
+import json
+
+import pytest
+
+from munajjam.benchmark.models import (
+    BenchmarkReport,
+    GroundTruthAyah,
+    GroundTruthSurah,
+    StrategyMetrics,
+)
+from munajjam.benchmark.runner import BenchmarkRunner
+from munajjam.core.aligner import AlignmentStrategy
+from munajjam.models import Segment, SegmentType
+
+
+def _make_ground_truth_surah_1() -> GroundTruthSurah:
+    """Create a minimal 3-ayah ground truth for Surah 1."""
+    return GroundTruthSurah(
+        surah_id=1,
+        reciter="test",
+        audio_filename="001.wav",
+        ayahs=[
+            GroundTruthAyah(
+                ayah_number=1, start_time=0.0, end_time=5.0,
+                text="بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+            ),
+            GroundTruthAyah(
+                ayah_number=2, start_time=5.5, end_time=10.0,
+                text="ٱلۡحَمۡدُ لِلَّهِ رَبِّ ٱلۡعَٰلَمِينَ",
+            ),
+            GroundTruthAyah(
+                ayah_number=3, start_time=10.5, end_time=14.0,
+                text="ٱلرَّحۡمَٰنِ ٱلرَّحِيمِ",
+            ),
+        ],
+    )
+
+
+class TestGroundTruthToSegments:
+    """Test conversion of ground-truth to Segment objects."""
+
+    def test_converts_to_segments(self, tmp_path) -> None:
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            results_dir=tmp_path,
+        )
+        gt = _make_ground_truth_surah_1()
+        segments = runner._ground_truth_to_segments(gt)
+
+        assert len(segments) == 3
+        assert all(isinstance(s, Segment) for s in segments)
+        assert segments[0].surah_id == 1
+        assert segments[0].start == 0.0
+        assert segments[0].end == 5.0
+        assert segments[0].type == SegmentType.AYAH
+        assert segments[0].text == "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ"
+
+    def test_segments_sorted_by_ayah_number(self, tmp_path) -> None:
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            results_dir=tmp_path,
+        )
+        gt = GroundTruthSurah(
+            surah_id=1,
+            reciter="test",
+            audio_filename="001.wav",
+            ayahs=[
+                GroundTruthAyah(ayah_number=3, start_time=10.0, end_time=14.0, text="c"),
+                GroundTruthAyah(ayah_number=1, start_time=0.0, end_time=5.0, text="a"),
+                GroundTruthAyah(ayah_number=2, start_time=5.0, end_time=10.0, text="b"),
+            ],
+        )
+        segments = runner._ground_truth_to_segments(gt)
+        assert segments[0].text == "a"
+        assert segments[1].text == "b"
+        assert segments[2].text == "c"
+
+
+class TestRunSurah:
+    """Test BenchmarkRunner.run_surah."""
+
+    def test_returns_metrics_per_strategy(self, tmp_path) -> None:
+        strategies = [AlignmentStrategy.GREEDY, AlignmentStrategy.DP, AlignmentStrategy.HYBRID]
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            results_dir=tmp_path,
+            strategies=strategies,
+        )
+        gt = _make_ground_truth_surah_1()
+        metrics_list = runner.run_surah(gt)
+
+        assert len(metrics_list) == 3
+        strategy_names = {m.strategy for m in metrics_list}
+        assert strategy_names == {"greedy", "dp", "hybrid"}
+
+    def test_metrics_have_valid_ranges(self, tmp_path) -> None:
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            results_dir=tmp_path,
+            strategies=[AlignmentStrategy.GREEDY],
+        )
+        gt = _make_ground_truth_surah_1()
+        metrics_list = runner.run_surah(gt)
+
+        assert len(metrics_list) == 1
+        m = metrics_list[0]
+        assert m.mae_start >= 0.0
+        assert m.mae_end >= 0.0
+        assert 0.0 <= m.avg_similarity <= 1.0
+        assert 0.0 <= m.pct_high_confidence <= 100.0
+        assert m.runtime_seconds >= 0.0
+        assert m.ayah_count >= 0
+
+    def test_single_strategy(self, tmp_path) -> None:
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            results_dir=tmp_path,
+            strategies=[AlignmentStrategy.DP],
+        )
+        gt = _make_ground_truth_surah_1()
+        metrics_list = runner.run_surah(gt)
+
+        assert len(metrics_list) == 1
+        assert metrics_list[0].strategy == "dp"
+
+
+class TestRunAll:
+    """Test BenchmarkRunner.run_all with fixture files."""
+
+    def test_loads_and_runs_all_ground_truth_files(self, tmp_path) -> None:
+        gt_dir = tmp_path / "ground_truth"
+        gt_dir.mkdir()
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+
+        # Write two ground truth files
+        for surah_id, ayah_count in [(1, 3), (112, 2)]:
+            data = {
+                "surah_id": surah_id,
+                "reciter": "test",
+                "audio_filename": f"{surah_id:03d}.wav",
+                "ayahs": [
+                    {
+                        "ayah_number": i + 1,
+                        "start_time": float(i * 5),
+                        "end_time": float(i * 5 + 4),
+                        "text": f"ayah {i + 1}",
+                    }
+                    for i in range(ayah_count)
+                ],
+            }
+            (gt_dir / f"surah_{surah_id:03d}.json").write_text(
+                json.dumps(data), encoding="utf-8",
+            )
+
+        runner = BenchmarkRunner(
+            ground_truth_dir=gt_dir,
+            results_dir=results_dir,
+            strategies=[AlignmentStrategy.GREEDY, AlignmentStrategy.DP],
+        )
+        report = runner.run_all()
+
+        assert isinstance(report, BenchmarkReport)
+        # 2 surahs * 2 strategies = 4 results
+        assert len(report.results) == 4
+        assert report.munajjam_version
+
+    def test_empty_ground_truth_dir(self, tmp_path) -> None:
+        gt_dir = tmp_path / "ground_truth"
+        gt_dir.mkdir()
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+
+        runner = BenchmarkRunner(
+            ground_truth_dir=gt_dir,
+            results_dir=results_dir,
+        )
+        report = runner.run_all()
+        assert report.results == []
+
+
+class TestSaveJson:
+    """Test BenchmarkRunner.save_json."""
+
+    def test_writes_valid_json(self, tmp_path) -> None:
+        report = BenchmarkReport(
+            generated_at="2026-02-26T12:00:00+00:00",
+            munajjam_version="2.0.0a1",
+            results=[
+                StrategyMetrics(
+                    strategy="greedy",
+                    surah_id=1,
+                    mae_start=0.1,
+                    mae_end=0.2,
+                    avg_similarity=0.9,
+                    pct_high_confidence=80.0,
+                    runtime_seconds=0.01,
+                    ayah_count=7,
+                    timestamp="2026-02-26T12:00:00+00:00",
+                ),
+            ],
+        )
+        output_path = tmp_path / "results" / "benchmark_results.json"
+        runner = BenchmarkRunner(
+            ground_truth_dir=tmp_path,
+            results_dir=tmp_path,
+        )
+        runner.save_json(report, output_path)
+
+        assert output_path.exists()
+        restored = BenchmarkReport.model_validate_json(
+            output_path.read_text(encoding="utf-8"),
+        )
+        assert restored.results[0].strategy == "greedy"


### PR DESCRIPTION
## Summary

Closes #45

- Add complete benchmark harness in `munajjam/benchmark/` (6 modules: models, loader, metrics, runner, leaderboard, __init__)
- Pydantic v2 models for ground-truth data, strategy metrics, and benchmark reports with strict validation (surah_id 1-114, end_time > start_time, similarity 0-1, etc.)
- Pure metric functions: MAE of start/end timestamps, average similarity score, percentage high-confidence ayahs
- `BenchmarkRunner` converts ground-truth ayahs into Segments and runs alignment strategies (GREEDY, DP, HYBRID) without GPU or real audio
- Markdown leaderboard generator with per-surah tables sorted by MAE and overall summary with per-strategy means
- Ground-truth JSON files for Surah Al-Fatiha (7 ayahs) and Surah Al-Ikhlas (4 ayahs)
- `.gitignore` updated to whitelist `benchmarks/ground_truth/*.json`

## Test plan

- [x] 62 unit tests covering models, loader, metrics, runner, leaderboard
- [x] 83 adversarial tests (grumpy tester) covering edge cases, boundary conditions, numerical hazards, file system errors
- [x] 145 total benchmark tests, **99% code coverage**
- [x] 234 total tests pass (full suite including pre-existing)
- [x] ruff check: clean
- [x] ruff format: clean
- [x] mypy: 0 errors in benchmark module
- [x] All 7 issue requirements verified with Python proof

## Bugs found and fixed during development

1. **`strategies=[]` silently fell back to defaults** — `[] or defaults` is falsy; fixed with `if strategies is not None`
2. **`list_ground_truth_files` returned `[]` for nonexistent directory** — Added `is_dir()` guard with `FileNotFoundError`
3. **`load_ground_truth` docstring incorrect** — Added `IsADirectoryError` to documented exceptions
4. **Missing `end_time > start_time` validation** — Added `model_validator` on `GroundTruthAyah`
5. **`zip()` without `strict=` ruff warning** — Resolved with `noqa: B905` (slicing already handles length)
6. **Metric functions not exported from `__init__.py`** — Added 4 metric function re-exports

## Ramadan Al-Athar Contribution

**Issue**: #45 (150 pts)
**Contributor**: @Hashem-Al-Qurashi
**Initiative**: Ramadan Al-Athar - ITQAN Community

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a comprehensive benchmarking framework to evaluate and compare alignment strategy performance.
  * Added leaderboard generation for benchmark results with detailed performance metrics and statistics.

* **Tests**
  * Added extensive test coverage for all benchmark functionality, including model validation, metrics computation, and edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->