### PR TITLE
Fix examples referencing removed APIs

### DIFF
--- a/examples/02_comparing_strategies.py
+++ b/examples/02_comparing_strategies.py
@@ -1,13 +1,11 @@
 """
 Comparing Alignment Strategies
 
-This example demonstrates the differences between the six alignment strategies:
+This example demonstrates the differences between the four alignment strategies:
 - Greedy: Fast, simple linear matching
 - DP: Optimal alignment using dynamic programming
-- Hybrid: DP with greedy fallback
-- Word-level DP: Sub-segment precision using per-word timestamps
-- CTC Segmentation: Acoustic-based alignment (requires audio_path)
-- Auto: Automatically picks the best strategy (recommended)
+- Hybrid: DP with greedy fallback (recommended)
+- Auto: Automatically picks the best strategy
 """
 
 from munajjam.transcription import WhisperTranscriber
@@ -75,7 +73,7 @@ def main():
     print(f"Loaded {len(ayahs)} ayahs")
 
     # Step 3: Test each strategy
-    strategies = ["greedy", "dp", "hybrid", "word_dp"]
+    strategies = ["greedy", "dp", "hybrid", "auto"]
     results_map = {}
 
     for strategy in strategies:
@@ -87,20 +85,6 @@ def main():
             "time": elapsed,
             "avg_similarity": avg_sim,
         }
-
-    # Step 3b: Test CTC segmentation (requires torchaudio)
-    try:
-        results, elapsed, avg_sim = align_with_strategy(
-            segments, ayahs, "ctc_seg", audio_path=audio_path
-        )
-        results_map["ctc_seg"] = {
-            "results": results,
-            "time": elapsed,
-            "avg_similarity": avg_sim,
-        }
-        strategies.append("ctc_seg")
-    except Exception as e:
-        print(f"\nSkipping CTC segmentation: {e}")
 
     # Step 4: Compare results
     print(f"\n{'=' * 80}")
@@ -134,19 +118,14 @@ For most use cases:
   • Use AUTO strategy (recommended) - Automatically picks the best approach
   • Includes automatic drift correction, overlap fixing, and zone realignment
 
-For word-level precision:
-  • Use WORD_DP strategy - Sub-segment alignment using per-word timestamps
-  • Best when faster-whisper provides word-level timing
+For balanced performance:
+  • Use HYBRID strategy - Combines DP quality with greedy fallback
 
-For acoustic alignment:
-  • Use CTC_SEG strategy - Frame-accurate boundaries from audio signal
-  • Requires audio_path and torchaudio
+For optimal alignment:
+  • Use DP strategy - Best alignment quality using dynamic programming
 
 For simple recordings:
   • Use GREEDY strategy - Fast and sufficient for 1:1 segment-to-ayah mapping
-
-For legacy workflows:
-  • HYBRID or DP strategies remain available for backward compatibility
     """)
 
 

--- a/examples/03_advanced_configuration.py
+++ b/examples/03_advanced_configuration.py
@@ -5,7 +5,7 @@ This example demonstrates advanced usage:
 - Custom configuration settings
 - Silence detection and usage
 - Progress tracking
-- CTC refinement and energy snap
+- Energy snap for precise boundaries
 - Detailed result inspection
 """
 
@@ -79,20 +79,19 @@ def main():
     print("\nStep 5: Aligning with advanced settings...")
 
     aligner = Aligner(
-        audio_path=audio_path,  # Audio file (required)
+        audio_path=audio_path,
         strategy="auto",
-        quality_threshold=0.85,  # Threshold for high-quality alignment
-        fix_drift=True,  # Enable zone realignment
-        fix_overlaps=True,  # Fix overlapping ayahs
-        ctc_refine=True,  # Refine boundaries with CTC forced alignment (default)
-        energy_snap=True,  # Snap boundaries to energy minima (default)
+        quality_threshold=0.85,
+        fix_drift=True,
+        fix_overlaps=True,
+        energy_snap=True,
     )
 
     results = aligner.align(
         segments=segments,
         ayahs=ayahs,
-        silences_ms=silences_ms,  # Use detected silences
-        on_progress=progress_callback,  # Track progress
+        silences_ms=silences_ms,
+        on_progress=progress_callback,
     )
 
     print(f"\n  Alignment complete: {len(results)} ayahs")


### PR DESCRIPTION
## Summary
- Remove references to removed `word_dp` and `ctc_seg` strategies from `examples/02_comparing_strategies.py`
- Remove removed `ctc_refine` parameter from `examples/03_advanced_configuration.py`
- Update docstrings and recommendations to reflect the current 4-strategy API (`greedy`, `dp`, `hybrid`, `auto`)

## Changes
| File | Change |
|------|--------|
| `examples/02_comparing_strategies.py` | Remove `word_dp` from strategies list, remove `ctc_seg` try/except block, update docstring from "six strategies" to "four strategies", update recommendations section |
| `examples/03_advanced_configuration.py` | Remove `ctc_refine=True` parameter (not in `Aligner.__init__`), update docstring to remove CTC refinement mention |

## Removed API References
- `AlignmentStrategy.WORD_DP` - not in current `AlignmentStrategy` enum
- `AlignmentStrategy.CTC_SEG` - not in current `AlignmentStrategy` enum
- `ctc_refine` parameter - not in current `Aligner.__init__()` signature

## Note
The test files (`test_aligner.py`, `test_zone_realigner.py`, `test_real_data.py`) already use only the current valid strategies and don't reference any removed APIs.

Fixes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `ctc_refine` parameter from Aligner initialization.

* **Documentation**
  * Simplified alignment strategy options to four core strategies: greedy, dp, hybrid, and auto.
  * Updated examples with clearer guidance for selecting the appropriate alignment strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->