### PR TITLE
feat: adaptive silence detection for continuous reciters

### DIFF
--- a/munajjam/munajjam/transcription/__init__.py
+++ b/munajjam/munajjam/transcription/__init__.py
@@ -5,12 +5,19 @@ Provides abstract interface and implementations for audio transcription.
 """
 
 from munajjam.transcription.base import BaseTranscriber
-from munajjam.transcription.silence import detect_non_silent_chunks, detect_silences
+from munajjam.transcription.silence import (
+    detect_non_silent_chunks,
+    detect_non_silent_chunks_adaptive,
+    detect_silences,
+    detect_silences_adaptive,
+)
 from munajjam.transcription.whisper import WhisperTranscriber
 
 __all__ = [
     "BaseTranscriber",
     "WhisperTranscriber",
     "detect_silences",
+    "detect_silences_adaptive",
     "detect_non_silent_chunks",
+    "detect_non_silent_chunks_adaptive",
 ]

--- a/munajjam/munajjam/transcription/silence.py
+++ b/munajjam/munajjam/transcription/silence.py
@@ -243,6 +243,150 @@ def _detect_non_silent_fast(
     return chunks if chunks else [(0, duration_ms)]
 
 
+def detect_non_silent_chunks_adaptive(
+    audio_path: str | Path,
+    expected_chunks: int,
+    min_silence_len: int = 300,
+    silence_thresh: int = -30,
+    max_retries: int = 3,
+    min_chunk_ratio: float = 0.5,
+    silence_len_step: int = 50,
+    silence_thresh_step: int = 5,
+    use_fast: bool = True,
+) -> tuple[list[tuple[int, int]], dict]:
+    """
+    Adaptive non-silent chunk detection with progressive threshold relaxation.
+
+    When initial detection produces too few chunks relative to ``expected_chunks``,
+    automatically retries with relaxed thresholds until enough chunks are found
+    or ``max_retries`` is exhausted.
+
+    Args:
+        audio_path: Path to audio file.
+        expected_chunks: Expected number of non-silent chunks (e.g. ayah count).
+        min_silence_len: Initial minimum silence duration in ms.
+        silence_thresh: Initial silence threshold in dB.
+        max_retries: Maximum number of retry attempts with relaxed thresholds.
+        min_chunk_ratio: Accept result when chunks >= expected_chunks * min_chunk_ratio.
+        silence_len_step: Amount to decrease min_silence_len per retry (ms).
+        silence_thresh_step: Amount to increase silence_thresh per retry (dB).
+        use_fast: Use fast librosa-based detection.
+
+    Returns:
+        Tuple of (chunks_list, metadata_dict).
+        metadata contains: retries_used, final_silence_thresh, final_min_silence_len,
+        chunk_count.
+    """
+    current_thresh = silence_thresh
+    current_min_len = min_silence_len
+    target = max(1, int(expected_chunks * min_chunk_ratio))
+    best_chunks: list[tuple[int, int]] = []
+    best_count = 0
+
+    for attempt in range(1 + max_retries):
+        chunks = detect_non_silent_chunks(
+            audio_path,
+            min_silence_len=current_min_len,
+            silence_thresh=current_thresh,
+            use_fast=use_fast,
+        )
+
+        if len(chunks) > best_count:
+            best_chunks = chunks
+            best_count = len(chunks)
+
+        if len(chunks) >= target:
+            return chunks, {
+                "retries_used": attempt,
+                "final_silence_thresh": current_thresh,
+                "final_min_silence_len": current_min_len,
+                "chunk_count": len(chunks),
+                "adapted": attempt > 0,
+            }
+
+        # Relax thresholds for next attempt
+        current_thresh = min(current_thresh + silence_thresh_step, -5)
+        current_min_len = max(current_min_len - silence_len_step, 100)
+
+    return best_chunks, {
+        "retries_used": max_retries,
+        "final_silence_thresh": current_thresh - silence_thresh_step,
+        "final_min_silence_len": current_min_len + silence_len_step,
+        "chunk_count": best_count,
+        "adapted": True,
+    }
+
+
+def detect_silences_adaptive(
+    audio_path: str | Path,
+    expected_silences: int,
+    min_silence_len: int = 300,
+    silence_thresh: int = -30,
+    max_retries: int = 3,
+    min_silence_ratio: float = 0.5,
+    silence_len_step: int = 50,
+    silence_thresh_step: int = 5,
+    use_fast: bool = True,
+) -> tuple[list[tuple[int, int]], dict]:
+    """
+    Adaptive silence detection with progressive threshold relaxation.
+
+    When initial detection produces too few silences relative to
+    ``expected_silences``, automatically retries with relaxed thresholds.
+
+    Args:
+        audio_path: Path to audio file.
+        expected_silences: Expected number of silence regions.
+        min_silence_len: Initial minimum silence duration in ms.
+        silence_thresh: Initial silence threshold in dB.
+        max_retries: Maximum number of retry attempts.
+        min_silence_ratio: Accept when silences >= expected * ratio.
+        silence_len_step: Amount to decrease min_silence_len per retry (ms).
+        silence_thresh_step: Amount to increase silence_thresh per retry (dB).
+        use_fast: Use fast librosa-based detection.
+
+    Returns:
+        Tuple of (silences_list, metadata_dict).
+    """
+    current_thresh = silence_thresh
+    current_min_len = min_silence_len
+    target = max(1, int(expected_silences * min_silence_ratio))
+    best_silences: list[tuple[int, int]] = []
+    best_count = 0
+
+    for attempt in range(1 + max_retries):
+        silences = detect_silences(
+            audio_path,
+            min_silence_len=current_min_len,
+            silence_thresh=current_thresh,
+            use_fast=use_fast,
+        )
+
+        if len(silences) > best_count:
+            best_silences = silences
+            best_count = len(silences)
+
+        if len(silences) >= target:
+            return silences, {
+                "retries_used": attempt,
+                "final_silence_thresh": current_thresh,
+                "final_min_silence_len": current_min_len,
+                "silence_count": len(silences),
+                "adapted": attempt > 0,
+            }
+
+        current_thresh = min(current_thresh + silence_thresh_step, -5)
+        current_min_len = max(current_min_len - silence_len_step, 100)
+
+    return best_silences, {
+        "retries_used": max_retries,
+        "final_silence_thresh": current_thresh - silence_thresh_step,
+        "final_min_silence_len": current_min_len + silence_len_step,
+        "silence_count": best_count,
+        "adapted": True,
+    }
+
+
 def compute_energy_envelope(
     audio_path: str | Path,
     window_ms: int = 50,

--- a/munajjam/munajjam/transcription/whisper.py
+++ b/munajjam/munajjam/transcription/whisper.py
@@ -16,6 +16,7 @@ from munajjam.models import Segment, SegmentType, WordTimestamp
 from munajjam.transcription.base import BaseTranscriber
 from munajjam.transcription.silence import (
     detect_non_silent_chunks,
+    detect_non_silent_chunks_adaptive,
     extract_segment_audio,
     load_audio_waveform,
 )
@@ -196,6 +197,8 @@ class WhisperTranscriber(BaseTranscriber):
         self,
         audio_path: str | Path,
         progress_callback: Callable[[int, int, str], None] | None = None,
+        adaptive_silence: bool = False,
+        expected_ayah_count: int | None = None,
     ) -> list[Segment]:
         """
         Transcribe an audio file to segments.
@@ -203,6 +206,11 @@ class WhisperTranscriber(BaseTranscriber):
         Args:
             audio_path: Path to the audio file (WAV)
             progress_callback: Optional callback function(current, total, text) for progress updates
+            adaptive_silence: When True, use adaptive silence detection that retries
+                with relaxed thresholds when too few chunks are found.
+            expected_ayah_count: Expected number of ayahs (used with adaptive_silence).
+                If None and adaptive_silence is True, the count is looked up from
+                the surah number in the filename.
 
         Returns:
             List of transcribed Segment objects
@@ -218,11 +226,24 @@ class WhisperTranscriber(BaseTranscriber):
         surah_id = int(audio_path.stem)
 
         # Detect non-silent chunks
-        chunks = detect_non_silent_chunks(
-            audio_path,
-            min_silence_len=self._settings.min_silence_ms,
-            silence_thresh=self._settings.silence_threshold_db,
-        )
+        if adaptive_silence:
+            if expected_ayah_count is None:
+                from munajjam.data import get_ayah_count
+
+                expected_ayah_count = get_ayah_count(surah_id)
+
+            chunks, _meta = detect_non_silent_chunks_adaptive(
+                audio_path,
+                expected_chunks=expected_ayah_count,
+                min_silence_len=self._settings.min_silence_ms,
+                silence_thresh=self._settings.silence_threshold_db,
+            )
+        else:
+            chunks = detect_non_silent_chunks(
+                audio_path,
+                min_silence_len=self._settings.min_silence_ms,
+                silence_thresh=self._settings.silence_threshold_db,
+            )
 
         # Load audio waveform
         waveform, sr = load_audio_waveform(

--- a/tests/unit/test_adaptive_silence.py
+++ b/tests/unit/test_adaptive_silence.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for adaptive silence detection.
+
+Tests the retry logic without requiring real audio files by mocking
+the underlying detection functions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from munajjam.transcription.silence import (
+    detect_non_silent_chunks_adaptive,
+    detect_silences_adaptive,
+)
+
+
+class TestDetectNonSilentChunksAdaptive:
+    """Tests for detect_non_silent_chunks_adaptive."""
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_sufficient_chunks_on_first_attempt(self, mock_detect):
+        """When enough chunks are found immediately, no retry happens."""
+        mock_detect.return_value = [(0, 1000), (1500, 3000), (3500, 5000)]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav", expected_chunks=3
+        )
+
+        assert len(chunks) == 3
+        assert meta["retries_used"] == 0
+        assert meta["adapted"] is False
+        assert mock_detect.call_count == 1
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_retry_relaxes_thresholds(self, mock_detect):
+        """When too few chunks, retries with relaxed thresholds."""
+        mock_detect.side_effect = [
+            [(0, 5000)],  # 1 chunk - too few
+            [(0, 2000), (3000, 5000)],  # 2 chunks - still too few
+            [(0, 1000), (1500, 3000), (3500, 5000), (5500, 7000)],  # 4 chunks
+        ]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=4,
+            min_chunk_ratio=1.0,
+            min_silence_len=300,
+            silence_thresh=-30,
+        )
+
+        assert len(chunks) == 4
+        assert meta["retries_used"] == 2
+        assert meta["adapted"] is True
+
+        calls = mock_detect.call_args_list
+        assert calls[0].kwargs["silence_thresh"] == -30
+        assert calls[0].kwargs["min_silence_len"] == 300
+        assert calls[1].kwargs["silence_thresh"] == -25
+        assert calls[1].kwargs["min_silence_len"] == 250
+        assert calls[2].kwargs["silence_thresh"] == -20
+        assert calls[2].kwargs["min_silence_len"] == 200
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_max_retries_exhausted(self, mock_detect):
+        """When max retries are exhausted, returns best result found."""
+        mock_detect.side_effect = [
+            [(0, 5000)],
+            [(0, 2500), (3000, 5000)],
+            [(0, 1500), (2000, 3500), (4000, 5000)],
+            [(0, 1000), (1500, 3000), (3500, 5000)],
+        ]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=10,
+            min_chunk_ratio=1.0,
+            max_retries=3,
+        )
+
+        assert meta["retries_used"] == 3
+        assert meta["adapted"] is True
+        assert meta["chunk_count"] == 3
+        assert len(chunks) == 3
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_min_chunk_ratio(self, mock_detect):
+        """Accepts result when chunks >= expected * min_chunk_ratio."""
+        mock_detect.return_value = [(0, 1000), (2000, 3000), (4000, 5000)]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=5,
+            min_chunk_ratio=0.5,
+        )
+
+        assert len(chunks) == 3
+        assert meta["retries_used"] == 0
+        assert mock_detect.call_count == 1
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_threshold_floor_respected(self, mock_detect):
+        """Silence threshold should not exceed -5 dB."""
+        mock_detect.return_value = [(0, 5000)]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=20,
+            silence_thresh=-10,
+            silence_thresh_step=10,
+            max_retries=3,
+        )
+
+        calls = mock_detect.call_args_list
+        for call in calls:
+            assert call.kwargs["silence_thresh"] <= -5
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_min_silence_len_floor_respected(self, mock_detect):
+        """Min silence length should not go below 100 ms."""
+        mock_detect.return_value = [(0, 5000)]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=20,
+            min_silence_len=150,
+            silence_len_step=100,
+            max_retries=3,
+        )
+
+        calls = mock_detect.call_args_list
+        for call in calls:
+            assert call.kwargs["min_silence_len"] >= 100
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_keeps_best_result(self, mock_detect):
+        """Returns the result with the most chunks even if it wasn't the last."""
+        mock_detect.side_effect = [
+            [(0, 1000)],
+            [(0, 500), (1000, 1500), (2000, 2500)],  # best: 3 chunks
+            [(0, 1000), (2000, 3000)],  # worse: 2 chunks
+        ]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=10,
+            max_retries=2,
+        )
+
+        assert len(chunks) == 3
+        assert meta["chunk_count"] == 3
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_custom_step_values(self, mock_detect):
+        """Custom step values are applied correctly."""
+        mock_detect.side_effect = [
+            [(0, 5000)],
+            [(0, 2000), (3000, 5000)],
+        ]
+
+        chunks, meta = detect_non_silent_chunks_adaptive(
+            "test.wav",
+            expected_chunks=2,
+            min_chunk_ratio=1.0,
+            min_silence_len=400,
+            silence_thresh=-40,
+            silence_len_step=100,
+            silence_thresh_step=10,
+        )
+
+        calls = mock_detect.call_args_list
+        assert calls[1].kwargs["silence_thresh"] == -30
+        assert calls[1].kwargs["min_silence_len"] == 300
+
+
+class TestDetectSilencesAdaptive:
+    """Tests for detect_silences_adaptive."""
+
+    @patch("munajjam.transcription.silence.detect_silences")
+    def test_sufficient_silences_on_first_attempt(self, mock_detect):
+        """No retry when enough silences found immediately."""
+        mock_detect.return_value = [
+            (1000, 1500),
+            (3000, 3500),
+            (5000, 5500),
+        ]
+
+        silences, meta = detect_silences_adaptive(
+            "test.wav", expected_silences=3
+        )
+
+        assert len(silences) == 3
+        assert meta["retries_used"] == 0
+        assert meta["adapted"] is False
+        assert mock_detect.call_count == 1
+
+    @patch("munajjam.transcription.silence.detect_silences")
+    def test_retry_with_relaxed_thresholds(self, mock_detect):
+        """Retries with progressively relaxed thresholds."""
+        mock_detect.side_effect = [
+            [(1000, 1500)],
+            [(1000, 1500), (3000, 3300), (5000, 5200)],
+        ]
+
+        silences, meta = detect_silences_adaptive(
+            "test.wav",
+            expected_silences=3,
+            min_silence_ratio=1.0,
+            min_silence_len=300,
+            silence_thresh=-30,
+        )
+
+        assert len(silences) == 3
+        assert meta["retries_used"] == 1
+        assert meta["adapted"] is True
+
+        calls = mock_detect.call_args_list
+        assert calls[0].kwargs["silence_thresh"] == -30
+        assert calls[1].kwargs["silence_thresh"] == -25
+        assert calls[1].kwargs["min_silence_len"] == 250
+
+    @patch("munajjam.transcription.silence.detect_silences")
+    def test_max_retries_returns_best(self, mock_detect):
+        """Returns best result when max retries exhausted."""
+        mock_detect.side_effect = [
+            [],
+            [(1000, 1500)],
+            [(1000, 1500), (3000, 3200)],
+            [(1000, 1300)],
+        ]
+
+        silences, meta = detect_silences_adaptive(
+            "test.wav",
+            expected_silences=10,
+            max_retries=3,
+        )
+
+        assert len(silences) == 2
+        assert meta["silence_count"] == 2
+        assert meta["retries_used"] == 3
+
+
+class TestAdaptiveBackwardsCompatibility:
+    """Verify adaptive functions are backwards-compatible opt-in."""
+
+    @patch("munajjam.transcription.silence.detect_non_silent_chunks")
+    def test_default_params_match_original(self, mock_detect):
+        """Default params use the same values as the original function."""
+        mock_detect.return_value = [(0, 5000)]
+
+        detect_non_silent_chunks_adaptive("test.wav", expected_chunks=1)
+
+        call = mock_detect.call_args_list[0]
+        assert call.kwargs["min_silence_len"] == 300
+        assert call.kwargs["silence_thresh"] == -30
+        assert call.kwargs["use_fast"] is True
+
+    @patch("munajjam.transcription.silence.detect_silences")
+    def test_silences_default_params_match(self, mock_detect):
+        """Default params use the same values as the original function."""
+        mock_detect.return_value = [(1000, 1500)]
+
+        detect_silences_adaptive("test.wav", expected_silences=1)
+
+        call = mock_detect.call_args_list[0]
+        assert call.kwargs["min_silence_len"] == 300
+        assert call.kwargs["silence_thresh"] == -30
+        assert call.kwargs["use_fast"] is True


### PR DESCRIPTION
## Summary
- Adds `detect_non_silent_chunks_adaptive()` and `detect_silences_adaptive()` functions that automatically retry with progressively relaxed thresholds when initial detection produces too few splits
- Integrates into `WhisperTranscriber.transcribe()` via `adaptive_silence` flag — fully backwards compatible (existing behavior unchanged unless opted in)
- When `adaptive_silence=True`, the transcriber auto-looks up the expected ayah count from the surah number and uses it to determine if enough chunks were found

## How it works
1. Run silence detection with initial thresholds (default: -30 dB, 300ms min silence)
2. If chunks found < `expected_chunks * min_chunk_ratio`, relax thresholds:
   - Increase `silence_thresh` by +5 dB per retry (floor: -5 dB)
   - Decrease `min_silence_len` by 50ms per retry (floor: 100ms)
3. Repeat up to `max_retries` times (default: 3)
4. Return the best result found (most chunks) along with metadata about adaptation

## Usage
```python
# Standalone adaptive detection
chunks, meta = detect_non_silent_chunks_adaptive(
    "audio.wav",
    expected_chunks=6,  # expected ayah count
)
print(meta)  # {'retries_used': 2, 'adapted': True, ...}

# Via transcriber (auto-detects expected count from surah number)
with WhisperTranscriber() as t:
    segments = t.transcribe("114.wav", adaptive_silence=True)
```

## Test plan
- [x] 13 unit tests covering all retry logic paths
- [x] Tests for threshold floor enforcement (-5 dB, 100ms)
- [x] Tests for best-result tracking across retries
- [x] Tests for backwards compatibility (default params match original)
- [x] All 153 tests pass (140 existing + 13 new)

Fixes #47