### PR TITLE
docs: explain how to run tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,14 @@ pytest tests/unit -v
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
+
+## Running tests locally
+To run tests locally you need to install the package from the internal
+`munajjam/` directory because the `pyproject.toml` file is located there.
+
+Example:
+
+cd munajjam
+pip install -e .
+cd ..
+pytest


### PR DESCRIPTION
This PR clarifies how to run tests locally.

The project contains `pyproject.toml` inside the internal `munajjam/` directory,
so contributors must install the package from there before running pytest.

Steps added to CONTRIBUTING.md:

cd munajjam
pip install -e .
cd ..
pytest

All tests pass locally (149 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with instructions for running tests locally during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->