### PR TITLE
feat(data): allow MUNAJJAM_QURAN_CSV env override for CSV path

### DIFF
--- a/munajjam/examples/example_alignment.py
+++ b/munajjam/examples/example_alignment.py
@@ -54,7 +54,6 @@ def run_with_transcription(audio_path: str, surah_id: int):
     transcriber = WhisperTranscriber()
     print("   Model loaded.")
 
-   
     segments = transcriber.transcribe(audio_path, surah_id=surah_id)
 
     transcribe_time = time.time() - start

--- a/munajjam/munajjam/data/quran.py
+++ b/munajjam/munajjam/data/quran.py
@@ -6,6 +6,7 @@ bundled CSV file.
 """
 
 import csv
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -21,6 +22,14 @@ def _get_data_path() -> Path:
 
 def _get_quran_csv_path() -> Path:
     """Get path to the Quran ayahs CSV file."""
+    # Allow an explicit override so embedders (e.g. the desktop app) can point
+    # at a CSV bundled outside the installed package.
+    override = os.environ.get("MUNAJJAM_QURAN_CSV")
+    if override:
+        override_path = Path(override)
+        if override_path.exists():
+            return override_path
+
     # First try bundled data
     bundled = _get_data_path() / "quran_ayat.csv"
     if bundled.exists():
@@ -33,7 +42,8 @@ def _get_quran_csv_path() -> Path:
 
     raise QuranDataError(
         "Quran ayahs CSV not found. "
-        "Expected at: munajjam/data/quran_ayat.csv or data/Quran Ayas List.csv"
+        "Expected at: munajjam/data/quran_ayat.csv or data/Quran Ayas List.csv "
+        "(set MUNAJJAM_QURAN_CSV to override)"
     )
 
 

--- a/munajjam/munajjam/transcription/base.py
+++ b/munajjam/munajjam/transcription/base.py
@@ -25,7 +25,7 @@ class BaseTranscriber(ABC):
         """Context manager support."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb):  # noqa: B027  # intentional no-op default; subclasses may override
         """Context manager support."""
         pass
 


### PR DESCRIPTION
## Summary

Lets embedders that ship the Quran ayahs CSV outside the installed Python package point `load_surah_ayahs` at it via an env var, instead of relying on `package_data` arriving correctly.

- Adds `MUNAJJAM_QURAN_CSV` env override at the top of `_get_quran_csv_path()`, ahead of the existing bundled and project-relative lookups.
- If the override is unset, empty, or points at a missing file, the existing fallbacks still fire — misconfiguration is graceful, not fatal.
- Error message updated so the env var name is discoverable.

Motivated by [Itqan-community/munajjam-desktop#17] — the desktop bundles `quran_ayat.csv` at `<install>/resources/data/quran_ayat.csv` (verified at runtime). Without this override, the desktop is locked to the upstream packaging being correct on every release.

## Test plan

- [ ] Existing unit tests pass (already verified locally: 14/14 in `tests/unit/test_data.py`).
- [ ] Manual: set `MUNAJJAM_QURAN_CSV` to a copy of the CSV at a non-default path, confirm `load_surah_ayahs(112)` returns the expected 4 ayahs.
- [ ] Manual: set `MUNAJJAM_QURAN_CSV` to a nonexistent path, confirm bundled fallback is used.
- [ ] Manual: set `MUNAJJAM_QURAN_CSV=""`, confirm bundled fallback is used (empty string treated as unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)