### PR TITLE
feat(transcription): add experimental Google Cloud Chirp 3 backend

### DIFF
--- a/docs/transcription-backend-research.md
+++ b/docs/transcription-backend-research.md
@@ -24,17 +24,18 @@
 
 ## Current State (Updated)
 
-Munajjam currently supports three transcription backends (configured via `model_type` in `munajjam/config.py` or `WhisperFactory`):
+Munajjam currently supports four transcription backends (configured via `model_type` in `munajjam/config.py` or `WhisperFactory`):
 
 | Setting | Value |
 |---------|-------|
 | API Server Default | `WhisperX` (large-v2) |
 | Library Default | `faster-whisper` (`OdyAsh/faster-whisper-base-ar-quran`) |
 | Alternative backend | `transformers` (HuggingFace pipeline) |
+| Experimental cloud backend | `chirp3` (Google Cloud Speech-to-Text V2; research only) |
 | Device | Auto-detect (CUDA > MPS > CPU) |
-| Word timestamps | `whisperx` (phoneme alignment) & `faster-whisper` (two-pass strategy) |
+| Word timestamps | `whisperx` (phoneme alignment) & `faster-whisper` (two-pass strategy); Chirp 3 word offsets for evaluation |
 
-The **WhisperX** backend is now the recommended default for the standalone API server, as it provides batched inference and phoneme-based forced alignment. This resolves the previous bottleneck where the **faster-whisper** backend's two-pass strategy doubled transcription time. The **transformers** backend remains for baseline compatibility.
+The **WhisperX** backend is now the recommended default for the standalone API server, as it provides batched inference and phoneme-based forced alignment. This resolves the previous bottleneck where the **faster-whisper** backend's two-pass strategy doubled transcription time. The **transformers** backend remains for baseline compatibility. **Chirp 3** is an optional research adapter (`--whisper-backend chirp3`) so cloud ASR can be compared with WhisperX; it is not a production default.
 
 ---
 

--- a/docs/transcription-backend-research.md
+++ b/docs/transcription-backend-research.md
@@ -277,6 +277,38 @@ Models discovered on Hugging Face, ranked by adoption:
 
 **Caveat**: Only benefits Apple Silicon users. Linux CUDA users are already well-served by faster-whisper.
 
+### Experimental: Google Cloud Chirp 3 (Issue #101)
+
+> ⚠️ **Research / evaluation only.** Chirp 3 is not a production Munajjam default. It exists so we can compare cloud ASR against local WhisperX without requiring a GPU.
+
+**What it is**: Google's Speech-to-Text V2 multilingual model (`chirp_3`). Munajjam talks to it through `ChirpTranscriber` (`munajjam/transcription/chirp.py`), registered as `WhisperBackend.CHIRP3` (`--whisper-backend chirp3`).
+
+| Criterion | Chirp 3 (cloud) | WhisperX (local default) |
+|-----------|-----------------|--------------------------|
+| Runtime | Google Cloud API; no local GPU/PyTorch | Local CUDA/CPU + wav2vec2 aligner |
+| Arabic (`ar-SA`) | Preview on Chirp 3 | Production (Whisper + `wav2vec2-large-xlsr-53-arabic`) |
+| Word timestamps | `enable_word_time_offsets=True` (word-level, not phoneme-level) | Phoneme-level forced alignment (best-in-class for this repo) |
+| Quran fine-tuning | None (general Arabic) | Can use Quran-tuned Whisper checkpoints |
+| Latency | Network RTT + cloud inference. Short surahs typically a few seconds; long recitations are chunked at 50s because `Recognize` is limited to ~1 minute | Dominated by model load + GPU/CPU decode; no network |
+| Auth / cost | GCP project, credentials, billed STT usage | Free after model download |
+| Integration | Optional extra: `pip install "munajjam[gcp]"` | Already the API-server default |
+
+**How timestamps are mapped**: Chirp returns free-form ASR words. Munajjam then fuzzy-matches those words onto canonical ayah text (same DP approach as WhisperX) and emits `Segment` + `WordTimestamp` objects so the rest of the pipeline (`Result` / `AlignmentResult` via `align()`) is unchanged.
+
+**Live accuracy numbers**: This change ships the adapter and mocked unit tests. A side-by-side WER / timestamp-error benchmark against WhisperX needs a GCP project and sample recitations (e.g. Al-Fatiha + a long surah). Until that run is recorded here, treat Chirp 3 as a *candidate*, not a replacement: expect weaker Tajweed/Quran-specific accuracy than WhisperX, in exchange for zero local GPU.
+
+**Configuration**
+
+```bash
+export GCP_PROJECT_ID="your-project"          # or MUNAJJAM_GCP_PROJECT_ID
+export GCP_CREDENTIALS_PATH="/path/key.json"  # or MUNAJJAM_GCP_CREDENTIALS_PATH
+export GCP_LOCATION="us"                      # us or eu; Chirp 3 is not on global
+```
+
+**Sources**: [Chirp 3 model docs](https://cloud.google.com/speech-to-text/docs/models/chirp-3), [Speech-to-Text V2 word offsets](https://cloud.google.com/speech-to-text/docs/samples/speech-transcribe-word-time-offsets-v2)
+
+---
+
 ### Not recommended
 
 | Backend | Reason |

--- a/munajjam/munajjam/config.py
+++ b/munajjam/munajjam/config.py
@@ -5,10 +5,11 @@ Uses Pydantic Settings for type-safe configuration with environment variable sup
 All settings can be overridden via environment variables with the MUNAJJAM_ prefix.
 """
 
+import os
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -139,7 +140,47 @@ class MunajjamSettings(BaseSettings):
         le=16,
     )
 
+    # ============ Google Cloud (experimental Chirp 3 backend) ============
+
+    gcp_project_id: str | None = Field(
+        default=None,
+        description="Google Cloud project id for the experimental Chirp 3 backend",
+    )
+
+    gcp_credentials_path: str | None = Field(
+        default=None,
+        description="Path to a GCP service-account JSON key file",
+    )
+
+    gcp_location: str = Field(
+        default="us",
+        description="Speech-to-Text V2 region for Chirp 3 (us or eu; not global)",
+    )
+
     # ============ Validators ============
+
+    @model_validator(mode="before")
+    @classmethod
+    def accept_unprefixed_gcp_env(cls, data: Any) -> Any:
+        """Also accept GCP_* env vars listed in issue #101, without the MUNAJJAM_ prefix."""
+        if not isinstance(data, dict):
+            return data
+
+        merged = dict(data)
+        aliases = {
+            "gcp_project_id": ("GCP_PROJECT_ID", "MUNAJJAM_GCP_PROJECT_ID"),
+            "gcp_credentials_path": ("GCP_CREDENTIALS_PATH", "MUNAJJAM_GCP_CREDENTIALS_PATH"),
+            "gcp_location": ("GCP_LOCATION", "MUNAJJAM_GCP_LOCATION"),
+        }
+        for field, keys in aliases.items():
+            if merged.get(field):
+                continue
+            for key in keys:
+                value = os.environ.get(key)
+                if value:
+                    merged[field] = value
+                    break
+        return merged
 
     @field_validator("device")
     @classmethod

--- a/munajjam/munajjam/transcription/chirp.py
+++ b/munajjam/munajjam/transcription/chirp.py
@@ -1,0 +1,365 @@
+"""
+Experimental Google Cloud Speech-to-Text Chirp 3 transcriber.
+
+This backend is for research/evaluation only. It calls the Speech-to-Text V2
+API (model ``chirp_3``, language ``ar-SA``) and maps word-level timestamps
+onto Munajjam ``Segment`` objects so results can be compared with WhisperX.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import math
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from rapidfuzz import fuzz
+
+from munajjam.config import MunajjamSettings, get_settings
+from munajjam.data import load_surah_ayahs
+from munajjam.exceptions import AudioFileError, ConfigurationError, TranscriptionError
+from munajjam.models import Segment, SegmentType, WordTimestamp
+from munajjam.transcription.base import BaseTranscriber
+
+logger = logging.getLogger(__name__)
+
+CHIRP3_MODEL = "chirp_3"
+CHIRP3_LANGUAGE = "ar-SA"
+# Speech.Recognize is intended for audio shorter than ~1 minute.
+MAX_CHUNK_SECONDS = 50.0
+_MIN_MATCH_RATIO = 0.6
+
+
+def _duration_to_seconds(duration: Any) -> float:
+    """Convert a protobuf Duration (or duck-typed mock) to seconds."""
+    if duration is None:
+        return 0.0
+    seconds = float(getattr(duration, "seconds", 0) or 0)
+    nanos = float(getattr(duration, "nanos", 0) or 0)
+    return seconds + nanos / 1e9
+
+
+def _normalize_arabic(text: str) -> str:
+    text = re.sub(r"[\u064B-\u065F\u06D6-\u06DC\u06DF-\u06E8\u06EA-\u06ED]", "", text)
+    text = re.sub(r"[أإآٱ]", "ا", text)
+    text = re.sub(r"[^\u0621-\u064A\s]", "", text)
+    return text.strip()
+
+
+def _map_words_to_ayah_segments(
+    *,
+    surah_id: int,
+    ref_ayahs: list[Any],
+    extracted_words: list[dict[str, Any]],
+) -> list[Segment]:
+    """Align ASR words onto canonical ayah text via fuzzy DP matching."""
+    ref_words: list[str] = []
+    for ayah in ref_ayahs:
+        ref_words.extend(ayah.text.split())
+
+    if not ref_words:
+        return []
+
+    n = len(ref_words)
+    m = len(extracted_words)
+    dp = np.zeros((n + 1, m + 1))
+
+    for i in range(1, n + 1):
+        rw = _normalize_arabic(ref_words[i - 1])
+        for j in range(1, m + 1):
+            ew = _normalize_arabic(str(extracted_words[j - 1]["word"]))
+            match_score = fuzz.ratio(rw, ew) / 100.0
+            if match_score < _MIN_MATCH_RATIO:
+                match_score = -1.0
+            dp[i][j] = max(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1] + match_score)
+
+    mapped: list[dict[str, Any] | None] = [None] * n
+    i, j = n, m
+    while i > 0 and j > 0:
+        rw = _normalize_arabic(ref_words[i - 1])
+        ew = _normalize_arabic(str(extracted_words[j - 1]["word"]))
+        match_score = fuzz.ratio(rw, ew) / 100.0
+        if match_score >= _MIN_MATCH_RATIO and math.isclose(
+            dp[i][j], dp[i - 1][j - 1] + match_score, rel_tol=1e-9, abs_tol=1e-9
+        ):
+            mapped[i - 1] = extracted_words[j - 1]
+            i -= 1
+            j -= 1
+        elif math.isclose(dp[i][j], dp[i - 1][j], rel_tol=1e-9, abs_tol=1e-9):
+            i -= 1
+        else:
+            j -= 1
+
+    alignments: list[dict[str, Any]] = []
+    for k in range(n):
+        hit = mapped[k]
+        if hit:
+            alignments.append(
+                {
+                    "word": ref_words[k],
+                    "start": float(hit["start"]),
+                    "end": float(hit["end"]),
+                    "confidence": float(hit.get("confidence") or 0.0),
+                }
+            )
+        else:
+            prev_end = alignments[-1]["end"] if alignments else 0.0
+            alignments.append(
+                {
+                    "word": ref_words[k],
+                    "start": prev_end,
+                    "end": prev_end + 0.1,
+                    "confidence": 0.0,
+                }
+            )
+
+    for k in range(len(alignments)):
+        if k > 0 and alignments[k]["start"] < alignments[k - 1]["end"]:
+            alignments[k]["start"] = alignments[k - 1]["end"]
+        if alignments[k]["end"] <= alignments[k]["start"]:
+            alignments[k]["end"] = round(alignments[k]["start"] + 0.1, 3)
+
+    segments: list[Segment] = []
+    word_idx = 0
+    for ayah in ref_ayahs:
+        ayah_word_count = len(ayah.text.split())
+        ayah_alignments = alignments[word_idx : word_idx + ayah_word_count]
+        word_idx += ayah_word_count
+        if not ayah_alignments:
+            continue
+
+        words = [
+            WordTimestamp(
+                word=item["word"],
+                start=item["start"],
+                end=item["end"],
+                probability=min(max(item["confidence"], 0.0), 1.0),
+            )
+            for item in ayah_alignments
+        ]
+        avg_conf = sum(w.probability for w in words) / len(words)
+        segments.append(
+            Segment(
+                id=ayah.ayah_number,
+                surah_id=surah_id,
+                start=words[0].start,
+                end=words[-1].end,
+                text=ayah.text,
+                type=SegmentType.AYAH,
+                words=words,
+                confidence=avg_conf,
+            )
+        )
+    return segments
+
+
+class ChirpTranscriber(BaseTranscriber):
+    """
+    Experimental Chirp 3 cloud transcriber.
+
+    Credentials are read from ``MunajjamSettings`` (``MUNAJJAM_GCP_*`` /
+    ``GCP_*`` env vars). The Google client library is imported lazily so the
+    rest of Munajjam does not require ``google-cloud-speech``.
+    """
+
+    def __init__(
+        self,
+        project_id: str | None = None,
+        credentials_path: str | Path | None = None,
+        location: str | None = None,
+        settings: MunajjamSettings | None = None,
+        *,
+        client: Any | None = None,
+    ) -> None:
+        self._settings = settings or get_settings()
+        self._project_id = project_id or self._settings.gcp_project_id
+        creds = (
+            credentials_path
+            if credentials_path is not None
+            else self._settings.gcp_credentials_path
+        )
+        self._credentials_path = Path(creds) if creds else None
+        self._location = location or self._settings.gcp_location
+        self._client = client
+
+    def transcribe(
+        self,
+        audio_path: str | Path,
+        *,
+        surah_id: int,
+        batch_size: int = 16,
+    ) -> list[Segment]:
+        del batch_size  # Cloud Recognize does not use local batching.
+        path = Path(audio_path)
+        if not path.is_file():
+            raise AudioFileError(str(path), reason="file does not exist")
+
+        self._ensure_configured()
+
+        ayahs = load_surah_ayahs(surah_id)
+        if not ayahs:
+            return []
+
+        try:
+            extracted_words = self._transcribe_words(path)
+        except (ConfigurationError, AudioFileError, TranscriptionError):
+            raise
+        except Exception as exc:
+            raise TranscriptionError(
+                f"Chirp 3 transcription failed: {exc}",
+                audio_path=str(path),
+            ) from exc
+
+        if not extracted_words:
+            raise TranscriptionError(
+                "Chirp 3 returned no word-level timestamps",
+                audio_path=str(path),
+            )
+
+        return _map_words_to_ayah_segments(
+            surah_id=surah_id,
+            ref_ayahs=ayahs,
+            extracted_words=extracted_words,
+        )
+
+    def _ensure_configured(self) -> None:
+        if not self._project_id:
+            raise ConfigurationError(
+                "Chirp 3 requires a Google Cloud project id. "
+                "Set MUNAJJAM_GCP_PROJECT_ID or GCP_PROJECT_ID.",
+                setting_name="gcp_project_id",
+            )
+        if self._credentials_path and not self._credentials_path.is_file():
+            raise ConfigurationError(
+                f"GCP credentials file not found: {self._credentials_path}",
+                setting_name="gcp_credentials_path",
+            )
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+
+        try:
+            from google.api_core.client_options import ClientOptions
+            from google.cloud.speech_v2 import SpeechClient
+        except ImportError as exc:
+            raise ConfigurationError(
+                "google-cloud-speech is required for the Chirp 3 backend. "
+                'Install it with: pip install "munajjam[gcp]" '
+                'or pip install "google-cloud-speech>=2.27.0".',
+                setting_name="gcp",
+            ) from exc
+
+        endpoint = f"{self._location}-speech.googleapis.com"
+        client_options = ClientOptions(api_endpoint=endpoint)
+
+        if self._credentials_path:
+            try:
+                from google.oauth2 import service_account
+            except ImportError as exc:
+                raise ConfigurationError(
+                    "google-auth is required to load a service-account JSON file.",
+                    setting_name="gcp_credentials_path",
+                ) from exc
+            credentials = service_account.Credentials.from_service_account_file(
+                str(self._credentials_path)
+            )
+            self._client = SpeechClient(credentials=credentials, client_options=client_options)
+        else:
+            # Fall back to Application Default Credentials / GOOGLE_APPLICATION_CREDENTIALS.
+            if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+                logger.debug("Using GOOGLE_APPLICATION_CREDENTIALS for Chirp 3")
+            self._client = SpeechClient(client_options=client_options)
+
+        return self._client
+
+    def _transcribe_words(self, audio_path: Path) -> list[dict[str, Any]]:
+        chunks = self._split_audio(audio_path)
+        words: list[dict[str, Any]] = []
+        for offset_seconds, chunk_bytes in chunks:
+            words.extend(self._recognize_chunk(chunk_bytes, time_offset=offset_seconds))
+        return words
+
+    def _split_audio(self, audio_path: Path) -> list[tuple[float, bytes]]:
+        """Split long recitations so each Recognize call stays under ~1 minute."""
+        try:
+            from pydub import AudioSegment
+        except ImportError:
+            return [(0.0, audio_path.read_bytes())]
+
+        audio = AudioSegment.from_file(str(audio_path))
+        duration_s = len(audio) / 1000.0
+        if duration_s <= MAX_CHUNK_SECONDS:
+            return [(0.0, audio_path.read_bytes())]
+
+        logger.info(
+            "Audio is %.1fs; splitting into %.0fs chunks for Chirp 3 Recognize",
+            duration_s,
+            MAX_CHUNK_SECONDS,
+        )
+        chunk_ms = int(MAX_CHUNK_SECONDS * 1000)
+        chunks: list[tuple[float, bytes]] = []
+        for start_ms in range(0, len(audio), chunk_ms):
+            piece = audio[start_ms : start_ms + chunk_ms]
+            buffer = io.BytesIO()
+            piece.export(buffer, format="wav")
+            chunks.append((start_ms / 1000.0, buffer.getvalue()))
+        return chunks
+
+    def _recognize_chunk(self, audio_bytes: bytes, *, time_offset: float) -> list[dict[str, Any]]:
+        try:
+            from google.cloud.speech_v2.types import cloud_speech
+        except ImportError as exc:
+            raise ConfigurationError(
+                "google-cloud-speech is required for the Chirp 3 backend.",
+                setting_name="gcp",
+            ) from exc
+
+        client = self._get_client()
+        config = cloud_speech.RecognitionConfig(
+            auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+            language_codes=[CHIRP3_LANGUAGE],
+            model=CHIRP3_MODEL,
+            features=cloud_speech.RecognitionFeatures(
+                enable_word_time_offsets=True,
+            ),
+        )
+        request = cloud_speech.RecognizeRequest(
+            recognizer=(f"projects/{self._project_id}/locations/{self._location}/recognizers/_"),
+            config=config,
+            content=audio_bytes,
+        )
+
+        try:
+            response = client.recognize(request=request)
+        except Exception as exc:
+            raise TranscriptionError(f"Google Cloud Speech-to-Text request failed: {exc}") from exc
+
+        return self._extract_words(response, time_offset=time_offset)
+
+    @staticmethod
+    def _extract_words(response: Any, *, time_offset: float) -> list[dict[str, Any]]:
+        words: list[dict[str, Any]] = []
+        for result in getattr(response, "results", []) or []:
+            alternatives = getattr(result, "alternatives", None) or []
+            if not alternatives:
+                continue
+            for word_info in getattr(alternatives[0], "words", []) or []:
+                start = time_offset + _duration_to_seconds(getattr(word_info, "start_offset", None))
+                end = time_offset + _duration_to_seconds(getattr(word_info, "end_offset", None))
+                if end < start:
+                    end = start
+                confidence = getattr(word_info, "confidence", 0.0) or 0.0
+                words.append(
+                    {
+                        "word": getattr(word_info, "word", "") or "",
+                        "start": start,
+                        "end": end,
+                        "confidence": float(confidence),
+                    }
+                )
+        return words

--- a/munajjam/munajjam/transcription/whisperFactory.py
+++ b/munajjam/munajjam/transcription/whisperFactory.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Literal
 
+from munajjam.transcription.base import BaseTranscriber
 from munajjam.transcription.whisper import WhisperTranscriber
 from munajjam.transcription.whisperx import Whisperx
 
@@ -9,6 +10,7 @@ class WhisperBackend(Enum):
     OPENAI = "openai"
     FASTERWHISPER = "fasterwhisper"
     WHISPERX = "whisperx"
+    CHIRP3 = "chirp3"
 
 
 class WhisperFactory:
@@ -18,7 +20,7 @@ class WhisperFactory:
         model_name: str,
         device: Literal["auto", "cpu", "cuda", "mps"] = "cuda",
         compute_type: str = "float16",
-    ) -> WhisperTranscriber | Whisperx:
+    ) -> BaseTranscriber:
         if backend == WhisperBackend.FASTERWHISPER:
             return WhisperTranscriber(
                 model_id=model_name, device=device, model_type="faster-whisper"
@@ -27,5 +29,9 @@ class WhisperFactory:
             return WhisperTranscriber(model_id=model_name, device=device, model_type="transformers")
         elif backend == WhisperBackend.WHISPERX:
             return Whisperx(model_name=model_name, device=device, compute_type=compute_type)
+        elif backend == WhisperBackend.CHIRP3:
+            from munajjam.transcription.chirp import ChirpTranscriber
+
+            return ChirpTranscriber()
         else:
             raise ValueError(f"Unsupported backend: {backend}")

--- a/munajjam/pyproject.toml
+++ b/munajjam/pyproject.toml
@@ -61,8 +61,11 @@ api = [
     "uvicorn>=0.23.0",
     "python-multipart>=0.0.6",
 ]
+gcp = [
+    "google-cloud-speech>=2.27.0",
+]
 all = [
-    "munajjam[dev,api]",
+    "munajjam[dev,api,gcp]",
 ]
 
 [project.scripts]

--- a/tests/unit/test_chirp.py
+++ b/tests/unit/test_chirp.py
@@ -1,0 +1,126 @@
+"""Unit tests for the experimental Chirp 3 transcription backend."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from munajjam.config import MunajjamSettings
+from munajjam.exceptions import AudioFileError, ConfigurationError, TranscriptionError
+from munajjam.models import Ayah, SegmentType
+from munajjam.transcription.chirp import ChirpTranscriber, _duration_to_seconds
+from munajjam.transcription.whisperFactory import WhisperBackend, WhisperFactory
+
+
+def test_whisper_factory_chirp3():
+    transcriber = WhisperFactory().create_whisper(
+        WhisperBackend.CHIRP3, "ignored", "cpu"
+    )
+    assert isinstance(transcriber, ChirpTranscriber)
+
+
+def test_duration_to_seconds():
+    duration = MagicMock()
+    duration.seconds = 1
+    duration.nanos = 500_000_000
+    assert _duration_to_seconds(duration) == pytest.approx(1.5)
+    assert _duration_to_seconds(None) == 0.0
+
+
+def test_extract_words_applies_time_offset():
+    word = MagicMock()
+    word.word = "الحمد"
+    word.confidence = 0.8
+    word.start_offset.seconds = 1
+    word.start_offset.nanos = 500_000_000
+    word.end_offset.seconds = 2
+    word.end_offset.nanos = 0
+    alternative = MagicMock(words=[word])
+    result = MagicMock(alternatives=[alternative])
+    response = MagicMock(results=[result])
+
+    words = ChirpTranscriber._extract_words(response, time_offset=10.0)
+    assert words == [
+        {
+            "word": "الحمد",
+            "start": pytest.approx(11.5),
+            "end": pytest.approx(12.0),
+            "confidence": 0.8,
+        }
+    ]
+
+
+def test_transcribe_missing_audio(tmp_path: Path):
+    transcriber = ChirpTranscriber(project_id="demo-project")
+    with pytest.raises(AudioFileError):
+        transcriber.transcribe(tmp_path / "missing.wav", surah_id=1)
+
+
+def test_transcribe_requires_project_id(tmp_path: Path):
+    audio = tmp_path / "s.wav"
+    audio.write_bytes(b"fake-audio")
+    transcriber = ChirpTranscriber(project_id="demo-project")
+    transcriber._project_id = None
+    with pytest.raises(ConfigurationError, match="project id"):
+        transcriber.transcribe(audio, surah_id=1)
+
+
+def test_transcribe_missing_credentials_file(tmp_path: Path):
+    audio = tmp_path / "s.wav"
+    audio.write_bytes(b"fake-audio")
+    transcriber = ChirpTranscriber(
+        project_id="demo-project",
+        credentials_path=tmp_path / "no-such-key.json",
+    )
+    with pytest.raises(ConfigurationError, match="credentials file"):
+        transcriber.transcribe(audio, surah_id=1)
+
+
+def test_transcribe_maps_words_to_ayah_segments(tmp_path: Path):
+    audio = tmp_path / "s.wav"
+    audio.write_bytes(b"fake-audio")
+    ayah = Ayah(id=1, surah_id=1, ayah_number=1, text="بسم الله")
+    transcriber = ChirpTranscriber(project_id="demo-project")
+    transcriber._transcribe_words = MagicMock(
+        return_value=[
+            {"word": "بسم", "start": 0.0, "end": 0.4, "confidence": 0.9},
+            {"word": "الله", "start": 0.4, "end": 0.9, "confidence": 0.95},
+        ]
+    )
+
+    with patch(
+        "munajjam.transcription.chirp.load_surah_ayahs",
+        return_value=[ayah],
+    ):
+        segments = transcriber.transcribe(audio, surah_id=1)
+
+    assert len(segments) == 1
+    assert segments[0].id == 1
+    assert segments[0].surah_id == 1
+    assert segments[0].type == SegmentType.AYAH
+    assert segments[0].text == "بسم الله"
+    assert segments[0].start == pytest.approx(0.0)
+    assert segments[0].end == pytest.approx(0.9)
+    assert segments[0].words is not None
+    assert [w.word for w in segments[0].words] == ["بسم", "الله"]
+
+
+def test_transcribe_empty_words_raises(tmp_path: Path):
+    audio = tmp_path / "s.wav"
+    audio.write_bytes(b"fake-audio")
+    transcriber = ChirpTranscriber(project_id="demo-project")
+    transcriber._transcribe_words = MagicMock(return_value=[])
+    with patch(
+        "munajjam.transcription.chirp.load_surah_ayahs",
+        return_value=[Ayah(id=1, surah_id=1, ayah_number=1, text="بسم")],
+    ), pytest.raises(TranscriptionError, match="no word-level timestamps"):
+        transcriber.transcribe(audio, surah_id=1)
+
+
+def test_gcp_settings_accept_unprefixed_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GCP_PROJECT_ID", "proj-from-env")
+    monkeypatch.setenv("GCP_LOCATION", "eu")
+    monkeypatch.delenv("MUNAJJAM_GCP_PROJECT_ID", raising=False)
+    monkeypatch.delenv("MUNAJJAM_GCP_LOCATION", raising=False)
+    settings = MunajjamSettings()
+    assert settings.gcp_project_id == "proj-from-env"
+    assert settings.gcp_location == "eu"

--- a/tests/unit/test_transcription.py
+++ b/tests/unit/test_transcription.py
@@ -54,6 +54,13 @@ def test_whisper_factory_unsupported(factory):
         factory.create_whisper("invalid_backend", "base", "cpu")
 
 
+def test_whisper_factory_chirp3(factory):
+    from munajjam.transcription.chirp import ChirpTranscriber
+
+    transcriber = factory.create_whisper(WhisperBackend.CHIRP3, "n/a", "cpu")
+    assert isinstance(transcriber, ChirpTranscriber)
+
+
 @patch("munajjam.transcription.whisperx.whisperx")
 def test_whisperx_transcribe(mock_whisperx_module):
     # Mock whisperx load_model and its returned model


### PR DESCRIPTION
Closes #101

Enable an optional Speech-to-Text V2 adapter so Quran alignment can be evaluated against Chirp 3 without local GPU inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Google Cloud Chirp 3 backend for Arabic transcription.
  * Added word-level timestamps, confidence scores, and ayah-aligned segments.
  * Added configurable WhisperX model size, pause detection, and Google Cloud settings.

* **Documentation**
  * Documented Chirp 3 setup, configuration, benchmarking limitations, and comparison with WhisperX.

* **Tests**
  * Added coverage for transcription, configuration, timestamps, alignment, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->