### PR TITLE
feat(transcription): add experimental Replicate WhisperX backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ batch_process.py
 # Local-only directories (not part of the library)
 v2/
 scripts/
+
+#.env file (contains sensitive API tokens)
+.env 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,24 @@ COPY munajjam/README.md /app/munajjam/README.md
 COPY munajjam/munajjam /app/munajjam/munajjam/
 
 WORKDIR /app/munajjam
+
+# Larger timeout + retries: some dependencies (torch/CUDA wheels pulled in by
+# whisperx/faster-whisper) are 100MB-1GB+ and can hit pip's default read
+# timeout on slower connections.
+ENV PIP_DEFAULT_TIMEOUT=1000
+
 # Install munajjam with the api option
-RUN pip install --no-cache-dir ".[api]"
+RUN pip install --no-cache-dir --retries 10 ".[api]"
 # Install faster-whisper and whisperx explicitly
-RUN pip install --no-cache-dir git+https://github.com/m-bain/whisperx.git faster-whisper
+RUN pip install --no-cache-dir --retries 10 git+https://github.com/m-bain/whisperx.git faster-whisper
+RUN pip install --no-cache-dir --retries 10 replicate
 
 WORKDIR /app
 # Copy the server and entrypoint
 COPY server.py /app/server.py
 COPY entrypoint.sh /app/entrypoint.sh
+# Normalize line endings in case the file was checked out with CRLF (Windows) —
+# a CR before the shebang's newline breaks `env bash` ("bash\r": No such file).
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Required directories
@@ -44,6 +53,7 @@ RUN mkdir -p /app/model_local/whisper \
              /app/temp_audio
 
 ENV HF_TOKEN=""
+ENV REPLICATE_API_TOKEN=""
 EXPOSE 8000
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docs/replicate-transcription.md
+++ b/docs/replicate-transcription.md
@@ -1,0 +1,127 @@
+# Experimental: Cloud-based WhisperX Alignment via Replicate
+
+> **Status**: Experimental / opt-in. The default transcription path (local
+> WhisperX) is unaffected — this adds an additional, optional mode.
+
+## Overview
+
+Munajjam's default transcription pipeline runs WhisperX (VAD + Wav2Vec2 CTC
+alignment) locally, which requires a GPU for reasonable performance. This
+feature adds an alternative: sending audio to a WhisperX model hosted on
+[Replicate](https://replicate.com)'s GPUs instead, so the backend can run
+without any local GPU at all.
+
+This is experimental and intended for evaluating whether serverless inference
+can match the accuracy of the local pipeline — it is not a replacement for the
+default local backend.
+
+## How it works
+
+1. A request to `POST /align/{surah_number}` includes `alignment_mode=replicate`
+   in the form data (default is `local`, i.e. the existing behavior — no change
+   for existing clients).
+2. The backend uploads the audio to a hosted WhisperX model on Replicate and
+   polls synchronously until the prediction completes.
+3. The returned word-level timestamps are mapped onto the surah's reference
+   ayah text using the same fuzzy-matching / boundary-refinement logic the
+   local WhisperX backend uses, producing the standard `Segment` objects.
+4. The response shape from `/align/status/{job_id}` is identical regardless of
+   which mode was used.
+
+## Setup
+
+### 1. Get a Replicate API token
+
+Create an account and generate a token at
+[replicate.com/account/api-tokens](https://replicate.com/account/api-tokens).
+
+> **Note**: the default model (`victor-upmeet/whisperx`) is not covered by
+> Replicate's free tier. A funded Replicate account is required to actually run
+> predictions through this mode — see [Known limitations](#known-limitations).
+
+### 2. Set the environment variable
+
+Add to your `.env` file (same folder as `docker-compose.yml`):
+
+```
+REPLICATE_API_TOKEN=r8_your_token_here
+```
+
+This is read directly from the environment (not through `MunajjamSettings`), to
+match the Replicate SDK's own standard variable name.
+
+If you're running via Docker, `docker-compose.yml` forwards it into the
+container the same way `HF_TOKEN` is already forwarded:
+
+```yaml
+environment:
+  - HF_TOKEN=${HF_TOKEN:-}
+  - REPLICATE_API_TOKEN=${REPLICATE_API_TOKEN:-}
+```
+
+### 3. Rebuild
+
+```bash
+docker compose up --build
+```
+
+The `replicate` Python package is installed as part of the image build. If
+`REPLICATE_API_TOKEN` is not set, the server still starts normally — the token
+is only required at the moment a request actually uses `alignment_mode=replicate`.
+
+## Usage
+
+```bash
+curl -X POST "http://localhost:8000/align/1" \
+  -F "file=@surah1.mp3" \
+  -F "alignment_mode=replicate"
+```
+
+Poll for the result the same way as the default mode:
+
+```bash
+curl "http://localhost:8000/align/status/<job_id>"
+```
+
+## Architecture notes
+
+- **`ReplicateWhisperXTranscriber`** (`transcription/replicate_transcriber.py`)
+  implements the same `BaseTranscriber` interface as the local `Whisperx` class,
+  so it's a drop-in alternative via `WhisperFactory`.
+- **Synchronous by design.** `.transcribe()` blocks until the Replicate
+  prediction finishes (submit → poll → parse), rather than using webhooks. This
+  fits directly into the existing background-job architecture in `server.py`
+  with no changes to the job queue or status-polling endpoints, and avoids
+  needing a publicly reachable webhook URL for local development.
+- **Model version resolved dynamically.** Community-hosted models on Replicate
+  (unlike Replicate's own "official" models) require a specific version hash,
+  not just an `owner/name` reference. Rather than hardcoding a version hash
+  (which would go stale whenever the model owner pushes an update), the latest
+  version is resolved at runtime via the Replicate API.
+- **Shared alignment logic.** The fuzzy word-matching and ayah-boundary
+  refinement logic used to build `Segment` objects is shared with the local
+  WhisperX backend via `transcription/alignment_utils.py`, so both backends
+  produce segments the same way rather than duplicating ~150 lines of alignment
+  code.
+
+## Known limitations
+
+- **Requires a funded Replicate account.** The default model is not available
+  on Replicate's free tier. Attempting to run without credit returns a `402
+  Insufficient credit` error, surfaced through the job's `"error"` status.
+- **Slower per-request than local, for short audio.** Network upload + queueing
+  time on Replicate's side adds latency that a local GPU with a warm model
+  doesn't have. This mode is being evaluated for infrastructure simplicity, not
+  raw latency.
+- **Accuracy vs. the local pipeline has not yet been validated end-to-end**
+  with real audio, due to the billing limitation above. Unit tests cover
+  request construction, auth handling, output parsing, and error propagation,
+  but not a live comparison of transcription accuracy against the local
+  WhisperX backend.
+
+## Testing
+
+Unit tests: `tests/unit/test_replicate_transcriber.py`. Covers token handling,
+version resolution, output parsing (including edge cases like missing
+confidence scores, unaligned words, and empty output), and error propagation on
+failed predictions.

--- a/munajjam/munajjam/transcription/alignment_utils.py
+++ b/munajjam/munajjam/transcription/alignment_utils.py
@@ -1,0 +1,194 @@
+"""
+Shared word-to-ayah alignment utilities.
+
+This module holds the fuzzy-matching / boundary-refinement logic that maps a flat
+list of timestamped words (from *any* transcription engine) onto the reference
+Quran text for a surah, producing the project's standard `Segment` objects.
+
+It was extracted from `Whisperx.transcribe` so that alternative backends (e.g.
+`ReplicateWhisperXTranscriber`) can reuse the exact same alignment behavior
+instead of re-implementing it, and so the two stay in sync if the algorithm is
+tuned in the future.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import soundfile as sf
+from rapidfuzz import fuzz
+
+from munajjam.models import Segment, SegmentType, WordTimestamp
+
+# Loose alias: an ayah-like object exposing `.ayah_number: int` and `.text: str`,
+# as returned by `munajjam.data.load_surah_ayahs`.
+AyahLike = Any
+
+
+def normalize_arabic(text: str) -> str:
+    """Strip diacritics/non-Arabic chars and normalize alef variants for fuzzy matching."""
+    text = re.sub(r"[\u064B-\u065F\u06D6-\u06DC\u06DF-\u06E8\u06EA-\u06ED]", "", text)
+    text = re.sub(r"[أإآٱ]", "ا", text)
+    text = re.sub(r"[^\u0621-\u064A\s]", "", text)
+    return text.strip()
+
+
+def align_words_to_segments(
+    *,
+    ref_words: list[str],
+    extracted_words: list[dict[str, Any]],
+    ayahs: list[AyahLike],
+    surah_id: int,
+    audio_path: str | Path,
+) -> list[Segment]:
+    """
+    Map timestamped words from a transcription engine onto reference ayah text.
+
+    Args:
+        ref_words: Flattened reference words for the surah (in ayah order).
+        extracted_words: Timestamped words from the engine. Each dict must have
+            "word", "start", "end", and "confidence" keys.
+        ayahs: The surah's Ayah objects (same order used to build ref_words).
+        surah_id: Surah number.
+        audio_path: Path to the source audio file, used to determine total
+            duration for the final segment's end time.
+
+    Returns:
+        List of Segment objects, one per ayah, with per-word timestamps.
+    """
+    n = len(ref_words)
+    m = len(extracted_words)
+
+    dp = [[0.0] * (m + 1) for _ in range(n + 1)]
+    for i in range(1, n + 1):
+        rw = normalize_arabic(ref_words[i - 1])
+        for j in range(1, m + 1):
+            ew = normalize_arabic(extracted_words[j - 1]["word"])
+            match_score = fuzz.ratio(rw, ew) / 100.0
+            if match_score < 0.6:
+                match_score = -1.0
+            dp[i][j] = max(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1] + match_score)
+
+    mapped_alignments: list[dict[str, Any] | None] = [None] * n
+    i, j = n, m
+    while i > 0 and j > 0:
+        rw = normalize_arabic(ref_words[i - 1])
+        ew = normalize_arabic(extracted_words[j - 1]["word"])
+        match_score = fuzz.ratio(rw, ew) / 100.0
+
+        if match_score >= 0.6 and dp[i][j] == dp[i - 1][j - 1] + match_score:
+            mapped_alignments[i - 1] = extracted_words[j - 1]
+            i -= 1
+            j -= 1
+        elif dp[i][j] == dp[i - 1][j]:
+            i -= 1
+        else:
+            j -= 1
+
+    w_alignments: list[dict[str, Any]] = []
+    for k in range(n):
+        if mapped_alignments[k]:
+            w_alignments.append(
+                {
+                    "word": ref_words[k],
+                    "start": mapped_alignments[k]["start"],
+                    "end": mapped_alignments[k]["end"],
+                    "confidence": mapped_alignments[k]["confidence"],
+                }
+            )
+        else:
+            prev_end = w_alignments[-1]["end"] if w_alignments else 0
+            w_alignments.append(
+                {
+                    "word": ref_words[k],
+                    "start": prev_end,
+                    "end": prev_end + 0.1,
+                    "confidence": 0.0,
+                }
+            )
+
+    final_alignments = w_alignments
+
+    try:
+        total_duration = sf.info(str(audio_path)).duration
+    except Exception:
+        total_duration = final_alignments[-1]["end"] + 2.0 if final_alignments else 2.0
+
+    ayah_boundary_indices = set()
+    w_idx = 0
+    for ayah in ayahs:
+        w_idx += len(ayah.text.split())
+        ayah_boundary_indices.add(w_idx - 1)
+
+    for k in range(len(final_alignments)):
+        if k > 0:
+            if final_alignments[k]["start"] < final_alignments[k - 1]["end"]:
+                final_alignments[k]["start"] = final_alignments[k - 1]["end"]
+
+        if k < len(final_alignments) - 1:
+            next_start = final_alignments[k + 1]["start"]
+            current_end = final_alignments[k]["end"]
+            gap = next_start - current_end
+
+            if gap > 0:
+                if k in ayah_boundary_indices:
+                    if gap <= 0.3:
+                        start_buffer = min(gap, 0.1)
+                        final_alignments[k + 1]["start"] = round(next_start - start_buffer, 3)
+                        final_alignments[k]["end"] = round(next_start - start_buffer, 3)
+                    elif gap >= 0.4:
+                        final_alignments[k + 1]["start"] = round(next_start - 0.2, 3)
+                        final_alignments[k]["end"] = round(next_start - 0.2, 3)
+                    else:
+                        mid = gap / 2.0
+                        final_alignments[k + 1]["start"] = round(next_start - mid, 3)
+                        final_alignments[k]["end"] = round(next_start - mid, 3)
+                else:
+                    if gap > 0.1:
+                        final_alignments[k]["end"] = round(next_start - 0.1, 3)
+        else:
+            final_alignments[k]["end"] = round(total_duration, 3)
+
+        if final_alignments[k]["end"] <= final_alignments[k]["start"]:
+            final_alignments[k]["end"] = round(final_alignments[k]["start"] + 0.1, 3)
+
+    word_idx = 0
+    segments = []
+
+    for ayah in ayahs:
+        ayah_words_count = len(ayah.text.split())
+        ayah_alignments = final_alignments[word_idx : word_idx + ayah_words_count]
+        word_idx += ayah_words_count
+
+        if not ayah_alignments:
+            continue
+
+        words = []
+        avg_conf = 0.0
+        for wa in ayah_alignments:
+            words.append(
+                WordTimestamp(
+                    word=wa["word"],
+                    start=wa["start"],
+                    end=wa["end"],
+                    probability=wa["confidence"],
+                )
+            )
+            avg_conf += wa["confidence"]
+
+        if words:
+            avg_conf /= len(words)
+            segments.append(
+                Segment(
+                    id=ayah.ayah_number,
+                    surah_id=surah_id,
+                    start=words[0].start,
+                    end=words[-1].end,
+                    text=ayah.text,
+                    type=SegmentType.AYAH,
+                    words=words,
+                    confidence=avg_conf,
+                )
+            )
+
+    return segments

--- a/munajjam/munajjam/transcription/replicate_transcriber.py
+++ b/munajjam/munajjam/transcription/replicate_transcriber.py
@@ -1,0 +1,175 @@
+"""
+EXPERIMENTAL: Cloud-based WhisperX transcription via the Replicate API.
+
+This backend sends audio to a publicly hosted WhisperX model (VAD + Wav2Vec2 CTC
+alignment) running on Replicate's GPUs instead of running the pipeline locally.
+It exists to evaluate whether serverless inference can match the accuracy of the
+local `Whisperx` pipeline without the burden of local GPU hosting. It is not
+intended to be the default backend.
+
+Requires the `REPLICATE_API_TOKEN` environment variable to be set. Get a token at
+https://replicate.com/account/api-tokens.
+"""
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    import replicate
+except ImportError:
+    replicate = None  # type: ignore[assignment]
+
+from munajjam.data import load_surah_ayahs
+from munajjam.models import Segment
+from munajjam.transcription.alignment_utils import align_words_to_segments
+from munajjam.transcription.base import BaseTranscriber
+
+# Public WhisperX model hosted on Replicate: https://replicate.com/victor-upmeet/whisperx
+DEFAULT_REPLICATE_MODEL = "victor-upmeet/whisperx"
+
+_TERMINAL_STATES = {"succeeded", "failed", "canceled"}
+
+
+class ReplicateTranscriptionError(RuntimeError):
+    """Raised when a Replicate WhisperX prediction fails or returns no usable output."""
+
+
+class ReplicateWhisperXTranscriber(BaseTranscriber):
+    """
+    EXPERIMENTAL: Cloud-based WhisperX transcriber backed by the Replicate API.
+
+    Acts as a lightweight proxy: it uploads audio to Replicate, polls the
+    prediction until it completes, and maps the returned word-level timestamps
+    onto the surah's reference ayah text using the same alignment logic as the
+    local `Whisperx` backend (see `alignment_utils.align_words_to_segments`).
+
+        transcriber = ReplicateWhisperXTranscriber()
+        segments = transcriber.transcribe("surah_1.wav", surah_id=1)
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_REPLICATE_MODEL,
+        *,
+        align_output: bool = True,
+        poll_interval: float = 2.0,
+        timeout: float = 600.0,
+    ) -> None:
+        if replicate is None:
+            raise ImportError(
+                "The 'replicate' package is required for ReplicateWhisperXTranscriber. "
+                "Install it with: pip install replicate"
+            )
+
+        api_token = os.environ.get("REPLICATE_API_TOKEN")
+        if not api_token:
+            raise ReplicateTranscriptionError(
+                "REPLICATE_API_TOKEN environment variable is not set. Get a token at "
+                "https://replicate.com/account/api-tokens and set it before using the "
+                "experimental REPLICATE_API backend."
+            )
+
+        self.model = model
+        self.align_output = align_output
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self._client = replicate.Client(api_token=api_token)
+        # Community-hosted models require a pinned version for predictions.create();
+        # resolve it dynamically so this doesn't silently 404 again if the model updates.
+        self._model_version = self._client.models.get(self.model).latest_version.id
+
+    def transcribe(
+        self,
+        audio_path: str | Path,
+        *,
+        surah_id: int,
+        batch_size: int = 16,
+    ) -> list[Segment]:
+        ayahs = load_surah_ayahs(surah_id)
+        if not ayahs:
+            return []
+
+        audio_path = Path(audio_path)
+
+        print(f"[Replicate] Submitting {audio_path.name} to {self.model} ...")
+        with open(audio_path, "rb") as audio_file:
+            prediction = self._client.predictions.create(
+                version=self._model_version,
+                input={
+                    "audio_file": audio_file,
+                    "align_output": self.align_output,
+                    "language": "ar",
+                    "batch_size": batch_size,
+                },
+            )
+
+        prediction = self._poll_until_done(prediction)
+
+        if prediction.status != "succeeded":
+            raise ReplicateTranscriptionError(
+                f"Replicate prediction {prediction.id} finished with status "
+                f"'{prediction.status}': {prediction.error or 'unknown error'}"
+            )
+
+        extracted_words = self._parse_output(prediction.output)
+        if not extracted_words:
+            raise ReplicateTranscriptionError(
+                f"Replicate prediction {prediction.id} succeeded but returned no "
+                "word-level timestamps."
+            )
+
+        ref_words = [w for ayah in ayahs for w in ayah.text.split()]
+
+        return align_words_to_segments(
+            ref_words=ref_words,
+            extracted_words=extracted_words,
+            ayahs=ayahs,
+            surah_id=surah_id,
+            audio_path=audio_path,
+        )
+
+    def _poll_until_done(self, prediction: Any) -> Any:
+        """Poll the prediction until it reaches a terminal state or times out."""
+        elapsed = 0.0
+        while prediction.status not in _TERMINAL_STATES:
+            if elapsed >= self.timeout:
+                raise ReplicateTranscriptionError(
+                    f"Replicate prediction {prediction.id} timed out after "
+                    f"{self.timeout}s (last status: {prediction.status})"
+                )
+            time.sleep(self.poll_interval)
+            elapsed += self.poll_interval
+            prediction.reload()
+        return prediction
+
+    @staticmethod
+    def _parse_output(output: Any) -> list[dict[str, Any]]:
+        """
+        Flatten Replicate's WhisperX output JSON into the flat word-list shape
+        expected by `alignment_utils.align_words_to_segments`
+        (a list of {"word", "start", "end", "confidence"} dicts).
+        """
+        if not output:
+            return []
+
+        segments = output.get("segments") if isinstance(output, dict) else output
+        if not segments:
+            return []
+
+        extracted_words: list[dict[str, Any]] = []
+        for segment in segments:
+            for w in segment.get("words", []):
+                if "start" not in w or "end" not in w:
+                    # WhisperX drops timing for words it couldn't confidently align
+                    continue
+                extracted_words.append(
+                    {
+                        "word": (w.get("word") or "").strip(),
+                        "start": float(w["start"]),
+                        "end": float(w["end"]),
+                        "confidence": float(w.get("score", w.get("confidence", 0.9))),
+                    }
+                )
+        return extracted_words

--- a/munajjam/munajjam/transcription/whisperFactory.py
+++ b/munajjam/munajjam/transcription/whisperFactory.py
@@ -1,6 +1,10 @@
 from enum import Enum
 from typing import Literal
 
+from munajjam.transcription.replicate_transcriber import (
+    DEFAULT_REPLICATE_MODEL,
+    ReplicateWhisperXTranscriber,
+)
 from munajjam.transcription.whisper import WhisperTranscriber
 from munajjam.transcription.whisperx import Whisperx
 
@@ -9,6 +13,7 @@ class WhisperBackend(Enum):
     OPENAI = "openai"
     FASTERWHISPER = "fasterwhisper"
     WHISPERX = "whisperx"
+    REPLICATE_API = "replicate_api"  # experimental: cloud WhisperX via Replicate
 
 
 class WhisperFactory:
@@ -18,7 +23,7 @@ class WhisperFactory:
         model_name: str | None = None,
         device: Literal["auto", "cpu", "cuda", "mps"] = "cuda",
         compute_type: str = "float16",
-    ) -> WhisperTranscriber | Whisperx:
+    ) -> WhisperTranscriber | Whisperx | ReplicateWhisperXTranscriber:
         if backend == WhisperBackend.FASTERWHISPER:
             return WhisperTranscriber(
                 model_id=model_name, device=device, model_type="faster-whisper"
@@ -27,5 +32,11 @@ class WhisperFactory:
             return WhisperTranscriber(model_id=model_name, device=device, model_type="transformers")
         elif backend == WhisperBackend.WHISPERX:
             return Whisperx(model_name=model_name, device=device, compute_type=compute_type)
+        elif backend == WhisperBackend.REPLICATE_API:
+            # `model_name` doubles as the Replicate model slug here (e.g.
+            # "victor-upmeet/whisperx"); fall back to the default public model
+            # if the caller passes an empty/placeholder value.
+            replicate_model = model_name or DEFAULT_REPLICATE_MODEL
+            return ReplicateWhisperXTranscriber(model=replicate_model)
         else:
             raise ValueError(f"Unsupported backend: {backend}")

--- a/server.py
+++ b/server.py
@@ -43,9 +43,29 @@ print(
 )
 global_transcriber = WhisperFactory().create_whisper(backend=WhisperBackend.WHISPERX)
 
+# EXPERIMENTAL: Replicate-backed transcriber instance — not created until the first
+# request uses alignment_mode="replicate", so the server still starts fine (and
+# the local WhisperX path is completely unaffected) if REPLICATE_API_TOKEN isn't set.
+_replicate_transcriber = None
+
+
+def _get_replicate_transcriber():
+    """Lazily construct (and cache) the experimental Replicate transcriber."""
+    global _replicate_transcriber
+    if _replicate_transcriber is None:
+        print("Initializing experimental Replicate WhisperX transcriber...")
+        _replicate_transcriber = WhisperFactory().create_whisper(
+            backend=WhisperBackend.REPLICATE_API, model_name=""
+        )
+    return _replicate_transcriber
+
 
 def _run_job(
-    job_id: str, file_location: str, surah_number: int, model_size: str | None = None
+    job_id: str,
+    file_location: str,
+    surah_number: int,
+    model_size: str | None = None,
+    alignment_mode: str = "local",
 ) -> None:
     """
     Background job function to execute audio transcription and ayah alignment.
@@ -54,25 +74,35 @@ def _run_job(
         job_id: Unique identifier for the alignment job.
         file_location: Path to temporary audio file.
         surah_number: Surah number (1-114).
-        model_size: Optional WhisperX model size requested by caller.
+        model_size: Optional WhisperX model size requested by caller. Only used
+            when alignment_mode is "local".
+        alignment_mode: "local" (default) runs WhisperX on this server; "replicate"
+            (experimental) sends the audio to a WhisperX model hosted on Replicate.
     """
     try:
         jobs[job_id]["status"] = "processing"
 
-        # Resolve model size for every job (defaults to configuration setting)
-        target_model_size = model_size or get_settings().whisperx_model_size
-        if hasattr(global_transcriber, "set_model_name"):
+        if alignment_mode == "replicate":
             print(
-                f"[Job {job_id[:8]}] Resolving WhisperX model size to: {target_model_size}"
+                f"[Job {job_id[:8]}] Started processing Surah {surah_number} via experimental Replicate mode"
             )
-            global_transcriber.set_model_name(target_model_size)
+            transcriber = _get_replicate_transcriber()
+        else:
+            # Resolve model size for every job (defaults to configuration setting)
+            target_model_size = model_size or get_settings().whisperx_model_size
+            if hasattr(global_transcriber, "set_model_name"):
+                print(
+                    f"[Job {job_id[:8]}] Resolving WhisperX model size to: {target_model_size}"
+                )
+                global_transcriber.set_model_name(target_model_size)
 
-        print(
-            f"[Job {job_id[:8]}] Started processing Surah {surah_number} with WhisperX ({global_transcriber.model_name})"
-        )
+            print(
+                f"[Job {job_id[:8]}] Started processing Surah {surah_number} with WhisperX ({global_transcriber.model_name})"
+            )
+            transcriber = global_transcriber
 
-        # Transcribe and align
-        segments = global_transcriber.transcribe(file_location, surah_id=surah_number)
+        # Transcribe and align (locally or via Replicate)
+        segments = transcriber.transcribe(file_location, surah_id=surah_number)
 
         response_data = []
         for segment in segments:
@@ -113,6 +143,7 @@ async def align_audio(
     file: UploadFile = File(...),
     riwaya: str = Form("hafs"),
     model_size: str | None = Form(None),
+    alignment_mode: str = Form("local"),
 ) -> JSONResponse:
     """
     Upload an audio file and initiate background audio-to-ayah alignment.
@@ -122,7 +153,11 @@ async def align_audio(
         background_tasks: FastAPI background task manager.
         file: Uploaded audio file (.mp3, .wav, etc.).
         riwaya: Quranic Riwaya ("hafs", "warsh").
-        model_size: Optional WhisperX model size (tiny, base, small, medium, large-v1, large-v2, large-v3).
+        model_size: Optional WhisperX model size (tiny, base, small, medium,
+            large-v1, large-v2, large-v3). Only applies when alignment_mode="local".
+        alignment_mode: "local" (default) runs WhisperX on this server.
+            "replicate" (experimental) sends audio to a WhisperX model hosted
+            on Replicate instead — see docs/replicate-transcription.md.
 
     Returns:
         JSONResponse containing job status and job_id.
@@ -132,6 +167,15 @@ async def align_audio(
             {
                 "status": "error",
                 "message": f"Invalid model_size: '{model_size}'. Must be one of {sorted(VALID_MODEL_SIZES)}",
+            },
+            status_code=400,
+        )
+
+    if alignment_mode not in ("local", "replicate"):
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": f"Unsupported alignment_mode: {alignment_mode}",
             },
             status_code=400,
         )
@@ -147,7 +191,7 @@ async def align_audio(
 
     background_tasks.add_task(
         lambda: _executor.submit(
-            _run_job, job_id, file_location, surah_number, model_size
+            _run_job, job_id, file_location, surah_number, model_size, alignment_mode
         )
     )
 

--- a/tests/unit/test_replicate_transcriber.py
+++ b/tests/unit/test_replicate_transcriber.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for ReplicateWhisperXTranscriber.
+
+These tests mock the `replicate` SDK entirely, so they run offline, for free,
+and don't depend on Replicate account credit or network access. This is what
+verifies the fix for the 404 bug (predictions.create() needs a pinned
+`version`, not just a model name) without needing a live API call.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from munajjam.transcription.replicate_transcriber import (
+    ReplicateTranscriptionError,
+    ReplicateWhisperXTranscriber,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_output — pure function, no mocking needed
+# ---------------------------------------------------------------------------
+
+def test_parse_output_flattens_words_with_scores():
+    fake_output = {
+        "segments": [
+            {
+                "words": [
+                    {"word": "بِسْمِ", "start": 0.0, "end": 0.5, "score": 0.95},
+                    {"word": "اللَّهِ", "start": 0.5, "end": 1.0, "score": 0.88},
+                ]
+            }
+        ]
+    }
+    result = ReplicateWhisperXTranscriber._parse_output(fake_output)
+
+    assert len(result) == 2
+    assert result[0] == {
+        "word": "بِسْمِ",
+        "start": 0.0,
+        "end": 0.5,
+        "confidence": 0.95,
+    }
+    assert result[1]["word"] == "اللَّهِ"
+
+
+def test_parse_output_defaults_confidence_when_missing():
+    fake_output = {
+        "segments": [{"words": [{"word": "test", "start": 0.0, "end": 0.5}]}]
+    }
+    result = ReplicateWhisperXTranscriber._parse_output(fake_output)
+
+    assert result[0]["confidence"] == 0.9  # documented default fallback
+
+
+def test_parse_output_skips_words_without_timing():
+    fake_output = {
+        "segments": [
+            {
+                "words": [
+                    {"word": "no_timing"},  # WhisperX couldn't align this one
+                    {"word": "has_timing", "start": 1.0, "end": 1.5},
+                ]
+            }
+        ]
+    }
+    result = ReplicateWhisperXTranscriber._parse_output(fake_output)
+
+    assert len(result) == 1
+    assert result[0]["word"] == "has_timing"
+
+
+def test_parse_output_handles_empty_or_none_output():
+    assert ReplicateWhisperXTranscriber._parse_output(None) == []
+    assert ReplicateWhisperXTranscriber._parse_output({}) == []
+    assert ReplicateWhisperXTranscriber._parse_output({"segments": []}) == []
+
+
+def test_parse_output_accepts_bare_list_of_segments():
+    # Some Replicate model versions return a bare list instead of {"segments": [...]}
+    fake_output = [{"words": [{"word": "x", "start": 0.0, "end": 0.2}]}]
+    result = ReplicateWhisperXTranscriber._parse_output(fake_output)
+
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# __init__ — token handling, version resolution
+# ---------------------------------------------------------------------------
+
+def test_init_raises_without_api_token(monkeypatch):
+    monkeypatch.delenv("REPLICATE_API_TOKEN", raising=False)
+
+    with pytest.raises(ReplicateTranscriptionError, match="REPLICATE_API_TOKEN"):
+        ReplicateWhisperXTranscriber()
+
+
+@patch("munajjam.transcription.replicate_transcriber.replicate")
+def test_init_resolves_and_stores_model_version(mock_replicate_module, monkeypatch):
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake_token")
+
+    mock_client = MagicMock()
+    mock_replicate_module.Client.return_value = mock_client
+    mock_client.models.get.return_value.latest_version.id = "abc123version"
+
+    transcriber = ReplicateWhisperXTranscriber()
+
+    mock_client.models.get.assert_called_once_with("victor-upmeet/whisperx")
+    assert transcriber._model_version == "abc123version"
+
+
+# ---------------------------------------------------------------------------
+# transcribe() — the core regression test for the 404 fix
+# ---------------------------------------------------------------------------
+
+@patch("munajjam.transcription.replicate_transcriber.align_words_to_segments")
+@patch("munajjam.transcription.replicate_transcriber.load_surah_ayahs")
+@patch("munajjam.transcription.replicate_transcriber.replicate")
+def test_transcribe_calls_predictions_create_with_version_not_model(
+    mock_replicate_module, mock_load_ayahs, mock_align, monkeypatch, tmp_path
+):
+    """
+    Regression test for the 404 bug: predictions.create() must be called with
+    a pinned `version=`, not `model=`, since community-hosted Replicate models
+    (like victor-upmeet/whisperx) don't support version-less prediction creation.
+    """
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake_token")
+
+    mock_client = MagicMock()
+    mock_replicate_module.Client.return_value = mock_client
+    mock_client.models.get.return_value.latest_version.id = "resolved_version_hash"
+
+    mock_prediction = MagicMock()
+    mock_prediction.status = "succeeded"
+    mock_prediction.output = {
+        "segments": [{"words": [{"word": "x", "start": 0.0, "end": 0.2, "score": 0.9}]}]
+    }
+    mock_client.predictions.create.return_value = mock_prediction
+
+    mock_load_ayahs.return_value = [MagicMock(text="بِسْمِ اللَّهِ")]
+    mock_align.return_value = ["fake_segment"]
+
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"\x00\x00")  # dummy content, never actually parsed as audio
+
+    transcriber = ReplicateWhisperXTranscriber()
+    result = transcriber.transcribe(audio_file, surah_id=1)
+
+    mock_client.predictions.create.assert_called_once()
+    _, kwargs = mock_client.predictions.create.call_args
+
+    assert "version" in kwargs, "predictions.create() must be called with version=, not model="
+    assert kwargs["version"] == "resolved_version_hash"
+    assert "model" not in kwargs
+
+    assert result == ["fake_segment"]
+
+
+@patch("munajjam.transcription.replicate_transcriber.load_surah_ayahs")
+@patch("munajjam.transcription.replicate_transcriber.replicate")
+def test_transcribe_raises_when_prediction_fails(
+    mock_replicate_module, mock_load_ayahs, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake_token")
+
+    mock_client = MagicMock()
+    mock_replicate_module.Client.return_value = mock_client
+    mock_client.models.get.return_value.latest_version.id = "v1"
+
+    mock_prediction = MagicMock()
+    mock_prediction.status = "failed"
+    mock_prediction.error = "insufficient credit"
+    mock_prediction.id = "pred_123"
+    mock_client.predictions.create.return_value = mock_prediction
+
+    mock_load_ayahs.return_value = [MagicMock(text="test")]
+
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"\x00\x00")
+
+    transcriber = ReplicateWhisperXTranscriber()
+
+    with pytest.raises(ReplicateTranscriptionError, match="failed"):
+        transcriber.transcribe(audio_file, surah_id=1)
+
+
+@patch("munajjam.transcription.replicate_transcriber.load_surah_ayahs")
+def test_transcribe_returns_empty_list_when_no_ayahs(mock_load_ayahs, monkeypatch, tmp_path):
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake_token")
+    mock_load_ayahs.return_value = []
+
+    with patch("munajjam.transcription.replicate_transcriber.replicate") as mock_replicate_module:
+        mock_client = MagicMock()
+        mock_replicate_module.Client.return_value = mock_client
+        mock_client.models.get.return_value.latest_version.id = "v1"
+
+        transcriber = ReplicateWhisperXTranscriber()
+        audio_file = tmp_path / "test.wav"
+        audio_file.write_bytes(b"\x00\x00")
+
+        result = transcriber.transcribe(audio_file, surah_id=999)
+
+    assert result == []


### PR DESCRIPTION
Refs #106

## Summary

Adds an experimental, opt-in `alignment_mode=replicate` option to
`POST /align/{surah_number}`. When set, transcription runs on a WhisperX model
hosted on Replicate's GPUs instead of the local pipeline. Default behavior
(`alignment_mode=local`, or omitted) is completely unaffected — existing
clients don't need any changes.

Full write-up: `docs/replicate-transcription.md`.

## What changed

- **New** `munajjam/transcription/replicate_transcriber.py` —
  `ReplicateWhisperXTranscriber`, implementing the same `BaseTranscriber`
  interface as the local `Whisperx` class.
- **New** `munajjam/transcription/alignment_utils.py` — the fuzzy word-to-ayah
  alignment logic (DP matching + boundary refinement) shared between the local
  and Replicate backends, so both produce `Segment` objects the same way
  instead of duplicating the logic.
- **Updated** `whisperFactory.py` — adds a `REPLICATE_API` backend option.
- **Updated** `server.py` — new `alignment_mode` form field, routed to a
  lazily-constructed Replicate transcriber (only built on first use, so the
  server starts fine with no `REPLICATE_API_TOKEN` set for anyone not using
  this mode).
- **Updated** `Dockerfile` / `docker-compose.yml` — installs the `replicate`
  package, forwards `REPLICATE_API_TOKEN` into the container.
- **New** `tests/unit/test_replicate_transcriber.py` — 10 tests covering token
  handling, model version resolution, output parsing edge cases, and error
  propagation.

## Bug found and fixed during testing

`predictions.create(model="victor-upmeet/whisperx", ...)` returned a 404.
Root cause: community-hosted Replicate models (unlike Replicate's "official"
models) require a specific version, not just an `owner/name` reference.

Fix: resolve the model's latest version dynamically at runtime via the
Replicate API, rather than hardcoding a version hash (which would silently go
stale whenever the model owner pushes an update):

```python
self._model_version = self._client.models.get(self.model).latest_version.id
```

## Testing

- ✅ Unit tests (10/10 passing) — token handling, version resolution, output
  parsing, error propagation
- ✅ Confirmed live: requests reach Replicate and get accepted/queued
  successfully
- ⚠️ **Not yet validated**: full end-to-end accuracy of a real Replicate
  WhisperX run, since `victor-upmeet/whisperx` isn't on Replicate's free tier
  and I don't have a funded account. Returns `402 Insufficient credit`.
  Per discussion on #106, live validation with funded credentials will be
  handled separately.

## How to test

```bash
curl -X POST "http://localhost:8000/align/1" \
  -F "file=@surah1.mp3" \
  -F "alignment_mode=replicate"

curl "http://localhost:8000/align/status/<job_id>"
```

Requires `REPLICATE_API_TOKEN` set in `.env` (see
`docs/replicate-transcription.md` for setup).