### PR TITLE
feat(transcription): introduce experimental cloud-based alignment via Deepgram API (#105)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/
 cover/
 
 # Translations

--- a/munajjam/munajjam/config.py
+++ b/munajjam/munajjam/config.py
@@ -8,7 +8,7 @@ All settings can be overridden via environment variables with the MUNAJJAM_ pref
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -63,6 +63,13 @@ class MunajjamSettings(BaseSettings):
     ] = Field(
         default="large-v2",
         description="WhisperX model size (tiny, base, small, medium, large-v1, large-v2, large-v3)",
+    )
+
+    # ============ Deepgram Settings (Experimental) ============
+
+    deepgram_api_key: SecretStr | None = Field(
+        default=None,
+        description="Deepgram API key for experimental cloud transcription",
     )
 
     # ============ Audio Processing ============

--- a/munajjam/munajjam/transcription/__init__.py
+++ b/munajjam/munajjam/transcription/__init__.py
@@ -6,11 +6,10 @@ Provides abstract interface and implementations for audio transcription.
 
 from munajjam.transcription.base import BaseTranscriber
 from munajjam.transcription.silence import detect_non_silent_chunks, detect_silences
-from munajjam.transcription.whisper import WhisperTranscriber
 
 __all__ = [
     "BaseTranscriber",
-    "WhisperTranscriber",
     "detect_silences",
     "detect_non_silent_chunks",
 ]
+

--- a/munajjam/munajjam/transcription/__init__.py
+++ b/munajjam/munajjam/transcription/__init__.py
@@ -4,12 +4,30 @@ Transcription module for Munajjam library.
 Provides abstract interface and implementations for audio transcription.
 """
 
+from typing import Any
+
 from munajjam.transcription.base import BaseTranscriber
 from munajjam.transcription.silence import detect_non_silent_chunks, detect_silences
 
 __all__ = [
     "BaseTranscriber",
+    "WhisperTranscriber",
+    "DeepgramTranscriber",
     "detect_silences",
     "detect_non_silent_chunks",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy-load transcriber classes on attribute access."""
+    if name == "WhisperTranscriber":
+        from munajjam.transcription.whisper import WhisperTranscriber
+
+        return WhisperTranscriber
+    elif name == "DeepgramTranscriber":
+        from munajjam.transcription.deepgram_transcriber import DeepgramTranscriber
+
+        return DeepgramTranscriber
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 

--- a/munajjam/munajjam/transcription/deepgram_transcriber.py
+++ b/munajjam/munajjam/transcription/deepgram_transcriber.py
@@ -1,0 +1,270 @@
+"""
+Experimental cloud-based transcription via Deepgram API.
+
+This module provides a lightweight, GPU-free transcriber that sends audio
+to the Deepgram cloud API and maps the returned word-level timestamps to
+Quran ayah boundaries using fuzzy DP alignment.
+
+No PyTorch, no whisperx, no CUDA — only httpx for HTTP calls.
+
+Requires:
+    pip install httpx   (or:  pip install munajjam[deepgram])
+
+Environment:
+    MUNAJJAM_DEEPGRAM_API_KEY=<your-key>
+"""
+
+from __future__ import annotations
+
+import gc
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from rapidfuzz import fuzz
+
+from munajjam.config import get_settings
+from munajjam.data import load_surah_ayahs
+from munajjam.exceptions import TranscriptionError
+from munajjam.models import Segment, SegmentType, WordTimestamp
+from munajjam.transcription.base import BaseTranscriber
+
+# Deepgram API endpoint for pre-recorded audio
+_DEEPGRAM_API_URL = "https://api.deepgram.com/v1/listen"
+
+
+def _normalize_arabic(text: str) -> str:
+    """Normalize Arabic text for fuzzy matching (strip diacritics, normalize alef)."""
+    text = re.sub(r"[\u064B-\u065F\u06D6-\u06DC\u06DF-\u06E8\u06EA-\u06ED]", "", text)
+    text = re.sub(r"[أإآٱ]", "ا", text)
+    text = re.sub(r"[^\u0621-\u064A\s]", "", text)
+    return text.strip()
+
+
+class DeepgramTranscriber(BaseTranscriber):
+    """
+    Experimental cloud transcriber using the Deepgram REST API.
+
+    Sends audio to Deepgram, retrieves word-level timestamps, and aligns
+    them to Quran ayah boundaries using fuzzy DP matching.
+
+    This transcriber does NOT require PyTorch, CUDA, or any local GPU.
+    """
+
+    def __init__(self) -> None:
+        settings = get_settings()
+        api_key = settings.deepgram_api_key
+        if api_key is None:
+            raise TranscriptionError(
+                "Deepgram API key is not configured. "
+                "Set MUNAJJAM_DEEPGRAM_API_KEY environment variable."
+            )
+        self._api_key = api_key.get_secret_value()
+
+    def _call_deepgram(self, audio_path: str | Path) -> dict[str, Any]:
+        """Send audio to Deepgram API and return the JSON response."""
+        try:
+            import httpx
+        except ImportError:
+            raise TranscriptionError(
+                "httpx is required for Deepgram mode. "
+                "Install with: pip install httpx  (or: pip install munajjam[deepgram])"
+            ) from None
+
+        audio_bytes = Path(audio_path).read_bytes()
+
+        headers = {
+            "Authorization": f"Token {self._api_key}",
+            "Content-Type": "audio/mpeg",
+        }
+        params = {
+            "model": "nova-3",
+            "language": "ar",
+            "utterances": "true",
+            "punctuate": "true",
+        }
+
+        response = httpx.post(
+            _DEEPGRAM_API_URL,
+            headers=headers,
+            params=params,
+            content=audio_bytes,
+            timeout=300.0,
+        )
+
+        if response.status_code != 200:
+            raise TranscriptionError(
+                f"Deepgram API error (HTTP {response.status_code}): {response.text}"
+            )
+
+        return response.json()
+
+    def _extract_words(
+        self, deepgram_response: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Extract word-level timestamps from Deepgram JSON response."""
+        try:
+            channels = deepgram_response["results"]["channels"]
+            alternatives = channels[0]["alternatives"]
+            words = alternatives[0].get("words", [])
+        except (KeyError, IndexError) as e:
+            raise TranscriptionError(
+                f"Unexpected Deepgram response structure: {e}"
+            ) from e
+
+        return [
+            {
+                "word": str(w["word"]),
+                "start": float(w["start"]),
+                "end": float(w["end"]),
+                "confidence": float(w.get("confidence", 0.9)),
+            }
+            for w in words
+            if "word" in w and "start" in w and "end" in w
+        ]
+
+    def transcribe(
+        self,
+        audio_path: str | Path,
+        *,
+        surah_id: int,
+        batch_size: int = 16,
+    ) -> list[Segment]:
+        """
+        Transcribe audio via Deepgram API and align to Quran ayahs.
+
+        Args:
+            audio_path: Path to the audio file.
+            surah_id: Surah number (1-114).
+            batch_size: Ignored (kept for interface compatibility).
+
+        Returns:
+            List of Segment objects aligned to ayah boundaries.
+        """
+        ayahs = load_surah_ayahs(surah_id)
+        if not ayahs:
+            return []
+
+        # Build reference word list from canonical Quran text
+        ref_words: list[str] = []
+        for ayah in ayahs:
+            for w in ayah.text.split():
+                ref_words.append(w)
+
+        # Call Deepgram API
+        print(f"[Deepgram] Sending audio to Deepgram API (nova-3, ar)...")
+        deepgram_response = self._call_deepgram(audio_path)
+        extracted_words = self._extract_words(deepgram_response)
+
+        if not extracted_words:
+            raise TranscriptionError(
+                "Deepgram returned no words. Check audio quality and language."
+            )
+
+        print(
+            f"[Deepgram] Received {len(extracted_words)} words, "
+            f"aligning to {len(ayahs)} ayahs..."
+        )
+
+        # --- Word-level DP alignment (same approach as whisperx.py) ---
+        n = len(ref_words)
+        m = len(extracted_words)
+        dp = np.zeros((n + 1, m + 1))
+
+        for i in range(1, n + 1):
+            rw = _normalize_arabic(ref_words[i - 1])
+            for j in range(1, m + 1):
+                ew = _normalize_arabic(str(extracted_words[j - 1]["word"]))
+                match_score = fuzz.ratio(rw, ew) / 100.0
+                if match_score < 0.6:
+                    match_score = -1.0
+                dp[i][j] = max(
+                    dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1] + match_score
+                )
+
+        # Backtrack to find optimal alignment
+        mapped_alignments: list[dict[str, Any] | None] = [None] * n
+        i, j = n, m
+        while i > 0 and j > 0:
+            rw = _normalize_arabic(ref_words[i - 1])
+            ew = _normalize_arabic(str(extracted_words[j - 1]["word"]))
+            match_score = fuzz.ratio(rw, ew) / 100.0
+
+            if match_score >= 0.6 and dp[i][j] == dp[i - 1][j - 1] + match_score:
+                mapped_alignments[i - 1] = extracted_words[j - 1]
+                i -= 1
+                j -= 1
+            elif dp[i][j] == dp[i - 1][j]:
+                i -= 1
+            else:
+                j -= 1
+
+        # Build final word alignments (fill gaps with estimated times)
+        w_alignments: list[dict[str, Any]] = []
+        for k in range(n):
+            align_item = mapped_alignments[k]
+            if align_item is not None:
+                w_alignments.append(
+                    {
+                        "word": ref_words[k],
+                        "start": align_item["start"],
+                        "end": align_item["end"],
+                        "confidence": align_item["confidence"],
+                    }
+                )
+            else:
+                prev_end = w_alignments[-1]["end"] if w_alignments else 0
+                w_alignments.append(
+                    {
+                        "word": ref_words[k],
+                        "start": prev_end,
+                        "end": prev_end + 0.1,
+                        "confidence": 0.0,
+                    }
+                )
+
+        gc.collect()
+
+        # --- Build Segment objects per ayah ---
+        word_idx = 0
+        segments: list[Segment] = []
+
+        for ayah in ayahs:
+            ayah_words_count = len(ayah.text.split())
+            ayah_alignments = w_alignments[word_idx : word_idx + ayah_words_count]
+            word_idx += ayah_words_count
+
+            if not ayah_alignments:
+                continue
+
+            words = []
+            avg_conf = 0.0
+            for wa in ayah_alignments:
+                words.append(
+                    WordTimestamp(
+                        word=wa["word"],
+                        start=wa["start"],
+                        end=wa["end"],
+                        probability=wa["confidence"],
+                    )
+                )
+                avg_conf += wa["confidence"]
+
+            if words:
+                avg_conf /= len(words)
+                segments.append(
+                    Segment(
+                        id=ayah.ayah_number,
+                        surah_id=surah_id,
+                        start=words[0].start,
+                        end=words[-1].end,
+                        text=ayah.text,
+                        type=SegmentType.AYAH,
+                        words=words,
+                        confidence=avg_conf,
+                    )
+                )
+
+        print(f"[Deepgram] Alignment complete: {len(segments)} ayah segments")
+        return segments

--- a/munajjam/munajjam/transcription/deepgram_transcriber.py
+++ b/munajjam/munajjam/transcription/deepgram_transcriber.py
@@ -153,7 +153,7 @@ class DeepgramTranscriber(BaseTranscriber):
                 ref_words.append(w)
 
         # Call Deepgram API
-        print(f"[Deepgram] Sending audio to Deepgram API (nova-3, ar)...")
+        print("[Deepgram] Sending audio to Deepgram API (nova-3, ar)...")
         deepgram_response = self._call_deepgram(audio_path)
         extracted_words = self._extract_words(deepgram_response)
 

--- a/munajjam/munajjam/transcription/whisperFactory.py
+++ b/munajjam/munajjam/transcription/whisperFactory.py
@@ -1,14 +1,14 @@
 from enum import Enum
 from typing import Literal
 
-from munajjam.transcription.whisper import WhisperTranscriber
-from munajjam.transcription.whisperx import Whisperx
+from munajjam.transcription.base import BaseTranscriber
 
 
 class WhisperBackend(Enum):
     OPENAI = "openai"
     FASTERWHISPER = "fasterwhisper"
     WHISPERX = "whisperx"
+    DEEPGRAM = "deepgram"
 
 
 class WhisperFactory:
@@ -18,14 +18,30 @@ class WhisperFactory:
         model_name: str | None = None,
         device: Literal["auto", "cpu", "cuda", "mps"] = "cuda",
         compute_type: str = "float16",
-    ) -> WhisperTranscriber | Whisperx:
+    ) -> BaseTranscriber:
         if backend == WhisperBackend.FASTERWHISPER:
+            from munajjam.transcription.whisper import WhisperTranscriber
+
             return WhisperTranscriber(
                 model_id=model_name, device=device, model_type="faster-whisper"
             )
         elif backend == WhisperBackend.OPENAI:
-            return WhisperTranscriber(model_id=model_name, device=device, model_type="transformers")
+            from munajjam.transcription.whisper import WhisperTranscriber
+
+            return WhisperTranscriber(
+                model_id=model_name, device=device, model_type="transformers"
+            )
         elif backend == WhisperBackend.WHISPERX:
-            return Whisperx(model_name=model_name, device=device, compute_type=compute_type)
-        else:
-            raise ValueError(f"Unsupported backend: {backend}")
+            from munajjam.transcription.whisperx import Whisperx
+
+            return Whisperx(
+                model_name=model_name, device=device, compute_type=compute_type
+            )
+        elif backend == WhisperBackend.DEEPGRAM:
+            from munajjam.transcription.deepgram_transcriber import (
+                DeepgramTranscriber,
+            )
+
+            return DeepgramTranscriber()
+
+        raise ValueError(f"Unsupported backend: {backend}")

--- a/munajjam/pyproject.toml
+++ b/munajjam/pyproject.toml
@@ -61,8 +61,11 @@ api = [
     "uvicorn>=0.23.0",
     "python-multipart>=0.0.6",
 ]
+deepgram = [
+    "httpx>=0.24.0",
+]
 all = [
-    "munajjam[dev,api]",
+    "munajjam[dev,api,deepgram]",
 ]
 
 [project.scripts]

--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from fastapi import BackgroundTasks, FastAPI, File, Form, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+
 from munajjam.config import get_settings
 from munajjam.transcription.base import BaseTranscriber
 from munajjam.transcription.whisperFactory import WhisperBackend, WhisperFactory

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ from fastapi import BackgroundTasks, FastAPI, File, Form, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from munajjam.config import get_settings
+from munajjam.transcription.base import BaseTranscriber
 from munajjam.transcription.whisperFactory import WhisperBackend, WhisperFactory
 
 app = FastAPI(title="Munajjam API Server")
@@ -33,19 +34,42 @@ VALID_MODEL_SIZES = {
     "large-v3",
 }
 
+# Valid alignment modes
+VALID_ALIGNMENT_MODES = {"whisperx", "deepgram"}
+
+# Map alignment_mode string → WhisperBackend enum
+_ALIGNMENT_MODE_MAP: dict[str, WhisperBackend] = {
+    "whisperx": WhisperBackend.WHISPERX,
+    "deepgram": WhisperBackend.DEEPGRAM,
+}
+
 # In-memory dictionary to store background job state
 jobs: dict = {}
 # Single-thread executor to prevent concurrent GPU execution / VRAM thrashing
 _executor = ThreadPoolExecutor(max_workers=1)
 
+# Lazy transcriber cache — backends are loaded only on first use
+_transcribers: dict[WhisperBackend, BaseTranscriber] = {}
+
 print(
-    "Initializing global WhisperX transcriber (models will be loaded lazily on first request)..."
+    "Munajjam API ready. Transcriber backends will be loaded lazily on first request."
 )
-global_transcriber = WhisperFactory().create_whisper(backend=WhisperBackend.WHISPERX)
+
+
+def _get_transcriber(backend: WhisperBackend) -> BaseTranscriber:
+    """Return a cached transcriber for the given backend, creating it on first use."""
+    if backend not in _transcribers:
+        print(f"Loading transcriber backend: {backend.value}")
+        _transcribers[backend] = WhisperFactory().create_whisper(backend=backend)
+    return _transcribers[backend]
 
 
 def _run_job(
-    job_id: str, file_location: str, surah_number: int, model_size: str | None = None
+    job_id: str,
+    file_location: str,
+    surah_number: int,
+    model_size: str | None = None,
+    alignment_mode: str = "whisperx",
 ) -> None:
     """
     Background job function to execute audio transcription and ayah alignment.
@@ -55,24 +79,30 @@ def _run_job(
         file_location: Path to temporary audio file.
         surah_number: Surah number (1-114).
         model_size: Optional WhisperX model size requested by caller.
+        alignment_mode: Backend to use ("whisperx" or "deepgram").
     """
     try:
         jobs[job_id]["status"] = "processing"
 
-        # Resolve model size for every job (defaults to configuration setting)
-        target_model_size = model_size or get_settings().whisperx_model_size
-        if hasattr(global_transcriber, "set_model_name"):
-            print(
-                f"[Job {job_id[:8]}] Resolving WhisperX model size to: {target_model_size}"
-            )
-            global_transcriber.set_model_name(target_model_size)
+        backend = _ALIGNMENT_MODE_MAP[alignment_mode]
+        transcriber = _get_transcriber(backend)
+
+        # Resolve model size (only applicable to WhisperX backend)
+        if backend == WhisperBackend.WHISPERX:
+            target_model_size = model_size or get_settings().whisperx_model_size
+            if hasattr(transcriber, "set_model_name"):
+                print(
+                    f"[Job {job_id[:8]}] Resolving WhisperX model size to: {target_model_size}"
+                )
+                transcriber.set_model_name(target_model_size)
 
         print(
-            f"[Job {job_id[:8]}] Started processing Surah {surah_number} with WhisperX ({global_transcriber.model_name})"
+            f"[Job {job_id[:8]}] Started processing Surah {surah_number} "
+            f"with {alignment_mode} backend"
         )
 
         # Transcribe and align
-        segments = global_transcriber.transcribe(file_location, surah_id=surah_number)
+        segments = transcriber.transcribe(file_location, surah_id=surah_number)
 
         response_data = []
         for segment in segments:
@@ -113,6 +143,7 @@ async def align_audio(
     file: UploadFile = File(...),
     riwaya: str = Form("hafs"),
     model_size: str | None = Form(None),
+    alignment_mode: str = Form("whisperx"),
 ) -> JSONResponse:
     """
     Upload an audio file and initiate background audio-to-ayah alignment.
@@ -123,10 +154,20 @@ async def align_audio(
         file: Uploaded audio file (.mp3, .wav, etc.).
         riwaya: Quranic Riwaya ("hafs", "warsh").
         model_size: Optional WhisperX model size (tiny, base, small, medium, large-v1, large-v2, large-v3).
+        alignment_mode: Backend to use for alignment ("whisperx" or "deepgram").
 
     Returns:
         JSONResponse containing job status and job_id.
     """
+    if alignment_mode not in VALID_ALIGNMENT_MODES:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": f"Invalid alignment_mode: '{alignment_mode}'. Must be one of {sorted(VALID_ALIGNMENT_MODES)}",
+            },
+            status_code=400,
+        )
+
     if model_size and model_size not in VALID_MODEL_SIZES:
         return JSONResponse(
             {
@@ -147,7 +188,7 @@ async def align_audio(
 
     background_tasks.add_task(
         lambda: _executor.submit(
-            _run_job, job_id, file_location, surah_number, model_size
+            _run_job, job_id, file_location, surah_number, model_size, alignment_mode
         )
     )
 

--- a/tests/unit/test_deepgram_transcriber.py
+++ b/tests/unit/test_deepgram_transcriber.py
@@ -4,15 +4,13 @@ Unit tests for DeepgramTranscriber.
 Tests use mocked HTTP responses to avoid requiring a real Deepgram API key.
 """
 
-import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from munajjam.exceptions import TranscriptionError
 from munajjam.models import Segment, SegmentType, WordTimestamp
 from munajjam.transcription.deepgram_transcriber import DeepgramTranscriber
-
 
 # ── Sample Deepgram API response ──────────────────────────────────────────
 
@@ -59,8 +57,6 @@ def mock_settings():
 @pytest.fixture
 def transcriber(mock_settings):
     """Create a DeepgramTranscriber with mocked settings."""
-    from munajjam.transcription.deepgram_transcriber import DeepgramTranscriber
-
     return DeepgramTranscriber()
 
 
@@ -72,18 +68,12 @@ class TestDeepgramTranscriberInit:
 
     def test_init_without_api_key_raises(self) -> None:
         """Must raise TranscriptionError when API key is not set."""
-        from munajjam.exceptions import TranscriptionError
-
         with patch("munajjam.transcription.deepgram_transcriber.get_settings") as mock:
             settings = MagicMock()
             settings.deepgram_api_key = None
             mock.return_value = settings
 
             with pytest.raises(TranscriptionError, match="API key is not configured"):
-                from munajjam.transcription.deepgram_transcriber import (
-                    DeepgramTranscriber,
-                )
-
                 DeepgramTranscriber()
 
     def test_init_with_api_key_succeeds(self, transcriber) -> None:
@@ -104,17 +94,13 @@ class TestDeepgramWordExtraction:
         assert words[0]["confidence"] == 0.97
 
     def test_extract_words_from_empty_response(self, transcriber) -> None:
-        """Must raise TranscriptionError for empty response."""
-        from munajjam.exceptions import TranscriptionError
-
+        """Must return empty list for empty response."""
         empty_response = {"results": {"channels": [{"alternatives": [{"words": []}]}]}}
         words = transcriber._extract_words(empty_response)
         assert words == []
 
     def test_extract_words_from_malformed_response(self, transcriber) -> None:
         """Must raise TranscriptionError for malformed response."""
-        from munajjam.exceptions import TranscriptionError
-
         with pytest.raises(TranscriptionError, match="Unexpected Deepgram response"):
             transcriber._extract_words({"bad": "data"})
 
@@ -124,8 +110,6 @@ class TestDeepgramAPICall:
 
     def test_api_error_raises_transcription_error(self, transcriber, tmp_path) -> None:
         """Must raise TranscriptionError on non-200 API response."""
-        from munajjam.exceptions import TranscriptionError
-
         audio_file = tmp_path / "test.mp3"
         audio_file.write_bytes(b"fake audio content")
 
@@ -133,9 +117,11 @@ class TestDeepgramAPICall:
         mock_response.status_code = 401
         mock_response.text = "Unauthorized"
 
-        with patch("httpx.post", return_value=mock_response):
-            with pytest.raises(TranscriptionError, match="HTTP 401"):
-                transcriber._call_deepgram(audio_file)
+        with (
+            patch("httpx.post", return_value=mock_response),
+            pytest.raises(TranscriptionError, match="HTTP 401"),
+        ):
+            transcriber._call_deepgram(audio_file)
 
     def test_successful_api_call(self, transcriber, tmp_path) -> None:
         """Must return parsed JSON from a successful API call."""

--- a/tests/unit/test_deepgram_transcriber.py
+++ b/tests/unit/test_deepgram_transcriber.py
@@ -1,0 +1,188 @@
+"""
+Unit tests for DeepgramTranscriber.
+
+Tests use mocked HTTP responses to avoid requiring a real Deepgram API key.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from munajjam.models import Segment, SegmentType, WordTimestamp
+from munajjam.transcription.deepgram_transcriber import DeepgramTranscriber
+
+
+# ── Sample Deepgram API response ──────────────────────────────────────────
+
+SAMPLE_DEEPGRAM_RESPONSE = {
+    "results": {
+        "channels": [
+            {
+                "alternatives": [
+                    {
+                        "transcript": "بسم الله الرحمن الرحيم",
+                        "confidence": 0.95,
+                        "words": [
+                            {"word": "بسم", "start": 0.5, "end": 0.9, "confidence": 0.97},
+                            {"word": "الله", "start": 0.9, "end": 1.3, "confidence": 0.99},
+                            {"word": "الرحمن", "start": 1.3, "end": 1.8, "confidence": 0.96},
+                            {"word": "الرحيم", "start": 1.8, "end": 2.3, "confidence": 0.98},
+                            {"word": "الحمد", "start": 2.5, "end": 2.9, "confidence": 0.95},
+                            {"word": "لله", "start": 2.9, "end": 3.2, "confidence": 0.94},
+                            {"word": "رب", "start": 3.2, "end": 3.5, "confidence": 0.93},
+                            {"word": "العالمين", "start": 3.5, "end": 4.1, "confidence": 0.97},
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_settings():
+    """Provide settings with a test Deepgram API key."""
+    with patch("munajjam.transcription.deepgram_transcriber.get_settings") as mock:
+        settings = MagicMock()
+        settings.deepgram_api_key = MagicMock()
+        settings.deepgram_api_key.get_secret_value.return_value = "test-api-key"
+        mock.return_value = settings
+        yield settings
+
+
+@pytest.fixture
+def transcriber(mock_settings):
+    """Create a DeepgramTranscriber with mocked settings."""
+    from munajjam.transcription.deepgram_transcriber import DeepgramTranscriber
+
+    return DeepgramTranscriber()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+class TestDeepgramTranscriberInit:
+    """Test DeepgramTranscriber initialization."""
+
+    def test_init_without_api_key_raises(self) -> None:
+        """Must raise TranscriptionError when API key is not set."""
+        from munajjam.exceptions import TranscriptionError
+
+        with patch("munajjam.transcription.deepgram_transcriber.get_settings") as mock:
+            settings = MagicMock()
+            settings.deepgram_api_key = None
+            mock.return_value = settings
+
+            with pytest.raises(TranscriptionError, match="API key is not configured"):
+                from munajjam.transcription.deepgram_transcriber import (
+                    DeepgramTranscriber,
+                )
+
+                DeepgramTranscriber()
+
+    def test_init_with_api_key_succeeds(self, transcriber) -> None:
+        """Must initialize successfully when API key is provided."""
+        assert transcriber._api_key == "test-api-key"
+
+
+class TestDeepgramWordExtraction:
+    """Test parsing of Deepgram API responses."""
+
+    def test_extract_words_from_valid_response(self, transcriber) -> None:
+        """Must correctly extract word timestamps from Deepgram JSON."""
+        words = transcriber._extract_words(SAMPLE_DEEPGRAM_RESPONSE)
+        assert len(words) == 8
+        assert words[0]["word"] == "بسم"
+        assert words[0]["start"] == 0.5
+        assert words[0]["end"] == 0.9
+        assert words[0]["confidence"] == 0.97
+
+    def test_extract_words_from_empty_response(self, transcriber) -> None:
+        """Must raise TranscriptionError for empty response."""
+        from munajjam.exceptions import TranscriptionError
+
+        empty_response = {"results": {"channels": [{"alternatives": [{"words": []}]}]}}
+        words = transcriber._extract_words(empty_response)
+        assert words == []
+
+    def test_extract_words_from_malformed_response(self, transcriber) -> None:
+        """Must raise TranscriptionError for malformed response."""
+        from munajjam.exceptions import TranscriptionError
+
+        with pytest.raises(TranscriptionError, match="Unexpected Deepgram response"):
+            transcriber._extract_words({"bad": "data"})
+
+
+class TestDeepgramAPICall:
+    """Test Deepgram API interaction."""
+
+    def test_api_error_raises_transcription_error(self, transcriber, tmp_path) -> None:
+        """Must raise TranscriptionError on non-200 API response."""
+        from munajjam.exceptions import TranscriptionError
+
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"fake audio content")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        with patch("httpx.post", return_value=mock_response):
+            with pytest.raises(TranscriptionError, match="HTTP 401"):
+                transcriber._call_deepgram(audio_file)
+
+    def test_successful_api_call(self, transcriber, tmp_path) -> None:
+        """Must return parsed JSON from a successful API call."""
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"fake audio content")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_DEEPGRAM_RESPONSE
+
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            result = transcriber._call_deepgram(audio_file)
+
+            # Verify the API was called with correct params
+            call_kwargs = mock_post.call_args
+            assert "Token test-api-key" in call_kwargs.kwargs["headers"]["Authorization"]
+            assert call_kwargs.kwargs["params"]["model"] == "nova-3"
+            assert call_kwargs.kwargs["params"]["language"] == "ar"
+
+        assert result == SAMPLE_DEEPGRAM_RESPONSE
+
+
+class TestDeepgramTranscription:
+    """Test full transcription pipeline with mocked API."""
+
+    def test_transcribe_returns_segments(self, transcriber, tmp_path) -> None:
+        """Full pipeline must return Segment objects with correct structure."""
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"fake audio content")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_DEEPGRAM_RESPONSE
+
+        with patch("httpx.post", return_value=mock_response):
+            segments = transcriber.transcribe(audio_file, surah_id=1)
+
+        # Al-Fatiha has 7 ayahs
+        assert len(segments) > 0
+        assert all(isinstance(s, Segment) for s in segments)
+
+        # Check first segment structure
+        first = segments[0]
+        assert first.surah_id == 1
+        assert first.type == SegmentType.AYAH
+        assert first.start >= 0.0
+        assert first.end > first.start
+        assert first.words is not None
+        assert len(first.words) > 0
+        assert all(isinstance(w, WordTimestamp) for w in first.words)

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -1,0 +1,80 @@
+"""
+Tests to verify that the lazy backend loading architecture works correctly.
+
+The critical acceptance criterion for Issue #105 is that selecting Deepgram
+mode must NOT import torch or whisperx. These tests verify this by running
+isolated subprocess checks.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+class TestLazyBackendImports:
+    """Verify that importing whisperFactory does not eagerly load heavy backends."""
+
+    def test_whisper_factory_import_does_not_load_torch(self) -> None:
+        """Importing whisperFactory should not trigger torch import."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "from munajjam.transcription.whisperFactory import "
+                    "WhisperFactory, WhisperBackend; "
+                    "assert 'torch' not in sys.modules, "
+                    "'torch was imported just by importing whisperFactory!'; "
+                    "assert 'whisperx' not in sys.modules, "
+                    "'whisperx was imported just by importing whisperFactory!'; "
+                    "print('PASS: No torch or whisperx loaded on import')"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"Lazy import test failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_deepgram_backend_does_not_load_torch(self) -> None:
+        """Creating a DeepgramTranscriber must not import torch or whisperx."""
+        env = {**os.environ, "MUNAJJAM_DEEPGRAM_API_KEY": "test-key-for-import-check"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "from munajjam.transcription.whisperFactory import "
+                    "WhisperFactory, WhisperBackend; "
+                    "factory = WhisperFactory(); "
+                    "transcriber = factory.create_whisper("
+                    "backend=WhisperBackend.DEEPGRAM); "
+                    "assert 'torch' not in sys.modules, "
+                    "'torch was imported in Deepgram mode!'; "
+                    "assert 'whisperx' not in sys.modules, "
+                    "'whisperx was imported in Deepgram mode!'; "
+                    "print('PASS: Deepgram mode loaded without torch/whisperx')"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"Deepgram torch-bypass test failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_whisper_backend_enum_has_deepgram(self) -> None:
+        """WhisperBackend enum must include DEEPGRAM value."""
+        from munajjam.transcription.whisperFactory import WhisperBackend
+
+        assert hasattr(WhisperBackend, "DEEPGRAM")
+        assert WhisperBackend.DEEPGRAM.value == "deepgram"

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -10,8 +10,6 @@ import os
 import subprocess
 import sys
 
-import pytest
-
 
 class TestLazyBackendImports:
     """Verify that importing whisperFactory does not eagerly load heavy backends."""
@@ -78,3 +76,58 @@ class TestLazyBackendImports:
 
         assert hasattr(WhisperBackend, "DEEPGRAM")
         assert WhisperBackend.DEEPGRAM.value == "deepgram"
+
+    def test_server_import_does_not_load_torch(self) -> None:
+        """Importing server.py itself must not load torch or whisperx into sys.modules."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "import server; "
+                    "assert 'torch' not in sys.modules, "
+                    "'torch was imported on server.py import!'; "
+                    "assert 'whisperx' not in sys.modules, "
+                    "'whisperx was imported on server.py import!'; "
+                    "print('PASS: server.py imported without torch/whisperx')"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"Server import isolation test failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_server_deepgram_transcriber_resolution_does_not_load_torch(self) -> None:
+        """Resolving Deepgram transcriber via server helper must not load torch."""
+        env = {**os.environ, "MUNAJJAM_DEEPGRAM_API_KEY": "test-key-for-import-check"}
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "from server import _get_transcriber; "
+                    "from munajjam.transcription.whisperFactory import WhisperBackend; "
+                    "t = _get_transcriber(WhisperBackend.DEEPGRAM); "
+                    "assert 'torch' not in sys.modules, "
+                    "'torch was imported during server Deepgram transcriber resolution!'; "
+                    "assert 'whisperx' not in sys.modules, "
+                    "'whisperx was imported during server Deepgram transcriber resolution!'; "
+                    "print('PASS: server Deepgram transcriber resolved without torch/whisperx')"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"Server Deepgram resolution test failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+

--- a/tests/unit/test_transcription.py
+++ b/tests/unit/test_transcription.py
@@ -204,16 +204,19 @@ def test_whisperx_set_model_name_swapping():
 
 
 @patch("server.get_settings")
-@patch("server.global_transcriber")
+@patch("server._get_transcriber")
 @patch("server.os.path.exists", return_value=False)
 def test_server_run_job_model_size_resolution(
-    mock_exists, mock_transcriber, mock_get_settings
+    mock_exists, mock_get_transcriber, mock_get_settings
 ):
     from server import _run_job, jobs
 
-    mock_get_settings.return_value.whisperx_model_size = "large-v2"
+    mock_transcriber = MagicMock()
     mock_transcriber.transcribe.return_value = []
     mock_transcriber.model_name = "large-v2"
+    mock_get_transcriber.return_value = mock_transcriber
+
+    mock_get_settings.return_value.whisperx_model_size = "large-v2"
 
     # Explicit model size provided
     jobs["job_1"] = {"status": "queued"}
@@ -224,3 +227,4 @@ def test_server_run_job_model_size_resolution(
     jobs["job_2"] = {"status": "queued"}
     _run_job("job_2", "dummy.mp3", 1, model_size=None)
     mock_transcriber.set_model_name.assert_called_with("large-v2")
+


### PR DESCRIPTION
## 📝 Description
Introduces an experimental, cloud-based alignment backend using the Deepgram API as an alternative to local WhisperX and GPU execution.

This mode enables running Munajjam on lightweight CPU-only environments without PyTorch or CUDA dependencies while maintaining precise word-level Quranic ayah alignment.

## 🚀 Key Changes

1. **Lazy Backend Architecture (`whisperFactory.py` & `server.py`):**
   - Transcriber backends (`WhisperTranscriber`, `Whisperx`, `DeepgramTranscriber`) are loaded lazily on-demand.
   - Eager global WhisperX initialization in `server.py` has been replaced with a lazy singleton registry (`_get_transcriber`).
   - Added `alignment_mode` parameter (`whisperx` | `deepgram`) to `/align/{surah_number}` with full backward compatibility (defaulting to `whisperx`).

2. **DeepgramTranscriber Implementation (`deepgram_transcriber.py`):**
   - Direct REST API integration with Deepgram using `httpx` (no heavy SDK dependencies).
   - Uses `nova-3` model with Arabic language (`ar`) support and word-level timestamp extraction.
   - Dynamic Programming alignment maps Deepgram word streams to canonical Quran ayahs and outputs standard `Segment` and `WordTimestamp` objects.

3. **Secure Configuration (`config.py` & `pyproject.toml`):**
   - Added `deepgram_api_key: SecretStr | None` via `MUNAJJAM_DEEPGRAM_API_KEY`.
   - `httpx` added as an optional dependency via `munajjam[deepgram]`.

4. **PEP 562 Backward Compatibility (`transcription/__init__.py`):**
   - Implemented `__getattr__` to maintain backward-compatible direct imports without triggering eager module loading.

## 🧪 Verification & Tests

- **100% Pass Rate:** All 235 unit tests in the repository pass.
- **Strict Isolation Verification (`test_lazy_imports.py`):** Subprocess-isolated tests confirm that neither importing `server.py`, importing `whisperFactory`, nor executing the Deepgram path loads `torch` or `whisperx` into `sys.modules`.
- **Linter & Formatting:** 100% clean under `ruff check`.

Fixes #105